### PR TITLE
fix(ci): trigger workflow on feature branches + ignore .claude/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - "feat/**"
+      - "fix/**"
+      - "docs/**"
+      - "data/**"
   pull_request:
     branches: [main]
 

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ scratch/
 notes-local/
 TODO-personal.md
 '@ | Set-Content -Path .gitignore -Encoding UTF8
+# Claude Code session state
+.claude/


### PR DESCRIPTION
## Problem

The CI workflow was configured to trigger only on push to `main` and on pull requests targeting `main`. Pushes to feature branches (e.g., `feat/data-2024-06`) did not run CI, so contributors discovered failures only when opening a PR.

This was caught when pushing the Phase 1 Curator commit to `feat/data-2024-06` and observing zero workflow runs in Actions.

Additionally, Claude Code creates a `.claude/` directory for session state that should never be committed, but it was missing from `.gitignore` on `main`.

## Fix

**`.github/workflows/ci.yml`**: extend the `push` trigger to include feature branch patterns:

- `feat/**` — feature branches (Builder, Curator)
- `fix/**` — bug fix branches
- `docs/**` — documentation-only branches
- `data/**` — reserved for future use (e.g., bulk data updates)

The existing `concurrency` block (cancel-in-progress) ensures that rapid-fire pushes cancel in-flight runs, so this change does not waste Actions minutes.

**`.gitignore`**: add `.claude/` so Claude Code session state is never committed by accident.

## Type of change

- [ ] Code (logic, refactor, new feature in `pulso/`)
- [ ] Data
- [ ] Scraper
- [ ] Tests
- [ ] Docs
- [x] CI / build

## Phase

- [x] 0 — Scaffolding (post-hoc fix discovered during Phase 1)

## Checklist

- [x] YAML syntax valid (`python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`)
- [x] No code or data changes — only the workflow trigger and gitignore
- [x] File written as UTF-8 without BOM, LF line endings