### PR TITLE
data(epochs): fix geih_2021_present encoding (utf-8 -> latin-1)

### DIFF
--- a/pulso/data/epochs.json
+++ b/pulso/data/epochs.json
@@ -31,7 +31,7 @@
         "persona": ["DIRECTORIO", "SECUENCIA_P", "ORDEN"],
         "hogar": ["DIRECTORIO", "SECUENCIA_P"]
       },
-      "encoding": "utf-8",
+      "encoding": "latin-1",
       "file_format": "csv",
       "separator": ";",
       "decimal": ",",

--- a/tests/unit/test_epochs.py
+++ b/tests/unit/test_epochs.py
@@ -11,7 +11,7 @@ def test_get_epoch_geih_2021_present() -> None:
     e = get_epoch("geih_2021_present")
     assert isinstance(e, Epoch)
     assert e.key == "geih_2021_present"
-    assert e.encoding == "utf-8"
+    assert e.encoding == "latin-1"
     assert e.file_format == "csv"
     assert e.separator == ";"
     assert e.decimal == ","


### PR DESCRIPTION
## Problem

When integration-testing `pulso.load(year=2024, month=6, module="ocupados", area="cabecera", harmonize=False)` against the real DANE ZIP (catalog 819), the parser fails with:
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd1 in position 34823: invalid continuation byte

`0xd1` is `Ñ` in latin-1. The schema declares `encoding: utf-8` for `geih_2021_present`, but the real ZIP is latin-1.

## Diagnosis

A diagnostic script run against the cached real DANE ZIP showed:

- 6 of 8 CSV files fail UTF-8 decode at byte sequences `0xd1` (Ñ) and `0xf1` (ñ)
- All 8 files decode cleanly with latin-1
- cp1252 also succeeds and produces text identical to latin-1 (cp1252 is a superset)
- The 2 files that happen to pass UTF-8 (`No ocupados.CSV`, `Otras formas de trabajo.CSV`) contain no accented data; they'd also work under latin-1

The original Curator inspection only checked the first line of each CSV (column headers, pure ASCII), missing the accented characters in data rows.

## Fix

Two changes in one commit (test depends directly on the data change):

1. `pulso/data/epochs.json`: `geih_2021_present.encoding` from `"utf-8"` to `"latin-1"`. Both epochs now consistent with DANE practice.
2. `tests/unit/test_epochs.py::test_get_epoch_geih_2021_present`: update assertion from `"utf-8"` to `"latin-1"` to match the new data.

## Verification

After this PR merges, this works end-to-end:

```python
import pulso
df = pulso.load(year=2024, month=6, module="ocupados", area="cabecera", harmonize=False)
assert df.shape[0] > 0
assert "DIRECTORIO" in df.columns
assert df["CLASE"].unique().tolist() == [1]
```

## Type of change

- [x] Data (`epochs.json`)
- [x] Tests (one assertion update tied to the data change)

## Phase

- [x] 1 — Vertical slice (closes the encoding gap discovered post-merge of PR #7)

## Checklist

- [x] Tests pass locally — 80 passed, 9 skipped, 0 failed
- [x] `validate_sources.py` passes
- [x] Schema unchanged (only a value within a valid field)
- [x] Awaiting human QA review and merge

## Notes for reviewer

- Phase 1 final close: this PR + PR #7 (parser Shape B) together fully enable `pulso.load()` against real DANE data.
- Lesson learned: future Curator inspections should sample data rows, not just column headers, to catch encoding issues. Consider adding this as a guideline in `CONTRIBUTING.md`.

