### PR TITLE
Phase 2 debt: variable_map domain fixes

### DIFF
--- a/PHASE_2_DATA_NOTES.md
+++ b/PHASE_2_DATA_NOTES.md
@@ -220,3 +220,55 @@ the actual source file. Verify with real GEIH-1 data.
 - [ ] Human verification of P3271 as sex variable in GEIH-2 (requires DANE questionnaire PDF)
 - [ ] Human verification of P7430 as tipo_inactividad in GEIH-2
 - [ ] Verification of GEIH-1 column codes against real data (P6051, OCI location, INGTOT availability)
+
+---
+
+## Phase 2 debt — domain fixes (branch `feat/data-domain-fixes`, 2026-04-29)
+
+End-to-end testing against real DANE 2024-06 data revealed three domain gaps in `variable_map.json`
+that were not visible during Phase 2 code review. Fixed in PR #11/#13.
+
+### Fix 1: `educ_max` — replaced GEIH-1 categories with official GEIH-2 categories
+
+**Problem:** The Phase 2 Curator populated `educ_max.categories` with 9 codes that reflect the
+GEIH-1 (P6210) codification. Real June 2024 data shows values 1–13 for P3042, not 1–9.
+
+**Fix:** Replaced all 9 categories with the 13 official DANE GEIH-2 categories plus code 99
+("No sabe, no informa"), as verified against **DANE catálogo 819, variable F63 (P3042)**:
+`https://microdatos.dane.gov.co/index.php/catalog/819/variable/F63/V4044?name=P3042`
+
+**Comparability note:** The GEIH-1 codification (P6210, 9 codes) collapses levels that GEIH-2 (P3042)
+distinguishes separately (e.g., code 1 = "Ninguno/Preescolar" in GEIH-1 corresponds to codes 1 and 2
+in GEIH-2; code 5 = "Técnica/Tecnológica" in GEIH-1 corresponds to codes 8 and 9 in GEIH-2). A
+crosswalk table is required for any longitudinal comparison across epochs. Documented in
+`comparability_warning`.
+
+### Fix 2: `parentesco_jefe` — added codes 11, 12, 13
+
+**Problem:** Variable map declared 10 categories (1–10). Real June 2024 data shows values 11
+(10 persons), 12 (4 persons), and 13 (780 persons, significant) that were missing from the domain.
+
+**Fix:** Extended `categories` to include:
+- `"11"`: `"Suegro/a (padre/madre del cónyuge)"` — best-guess label
+- `"12"`: `"Yerno/Nuera (cónyuge del hijo/a)"` — best-guess label
+- `"13"`: `"Hermano/a"` — best-guess label (780 persons make this category non-trivial)
+
+**Open uncertainty:** The exact DANE labels for codes 11, 12, 13 could not be confirmed against the
+GEIH-2 questionnaire PDF or DANE microdata catalog. The labels are conservative guesses based on
+typical family-relationship expansions in the 2021 redesign. **REQUIRES HUMAN VERIFICATION** against
+the official DANE GEIH-2 questionnaire or the microdatos catalog before using these codes in
+published analysis. Documented in `comparability_warning`.
+
+### Fix 3: `tipo_contrato` — added code 9 (No sabe / No informa)
+
+**Problem:** Variable map declared categories 1–4. Real data contains value 9 (7 persons).
+
+**Fix:** Added `"9"`: `"No sabe / No informa"`. Standard DANE convention for categorical variables;
+no special verification required.
+
+### Variables intentionally NOT touched
+
+- **`vivienda_propia`** and **`ingreso_total`**: Their `module` field is correct in `variable_map.json`.
+  The issue is that `load_merged` does not auto-include the required modules (`vivienda_hogares`,
+  `otros_ingresos`) when these variables are requested. This is a Builder/code problem, tracked as
+  **Issue #14** (Builder territory). No changes to `variable_map.json` needed for these variables.

--- a/pulso/data/variable_map.json
+++ b/pulso/data/variable_map.json
@@ -102,9 +102,12 @@
         "7": "Pensionista",
         "8": "Trabajador del hogar sin remuneración",
         "9": "Otro no pariente",
-        "10": "Sin información"
+        "10": "Sin información",
+        "11": "Suegro/a (padre/madre del cónyuge)",
+        "12": "Yerno/Nuera (cónyuge del hijo/a)",
+        "13": "Hermano/a"
       },
-      "comparability_warning": "El código de la pregunta puede variar entre P6050 y P6051 según el año de la encuesta. Verificar con diccionario del año correspondiente.",
+      "comparability_warning": "El código de la pregunta puede variar entre P6050 y P6051 según el año de la encuesta. Verificar con diccionario del año correspondiente. ADVERTENCIA: Los códigos 11, 12 y 13 se observan en los datos reales de June 2024 (10, 4 y 780 personas respectivamente) pero sus etiquetas son ESTIMACIONES CONSERVADORAS basadas en patrones típicos del rediseño GEIH-2 de 2021. REQUIEREN VERIFICACIÓN HUMANA contra el cuestionario PDF o el catálogo de microdatos DANE GEIH-2.",
       "mappings": {
         "geih_2006_2020": {
           "source_variable": "P6051",
@@ -235,17 +238,22 @@
       "description_es": "Nivel educativo más alto alcanzado y aprobado.",
       "description_en": "Highest educational level attained and approved.",
       "categories": {
-        "1": "Ninguno/Preescolar",
-        "2": "Básica primaria",
-        "3": "Básica secundaria",
-        "4": "Media (bachillerato)",
-        "5": "Técnica profesional o tecnológica",
-        "6": "Universitaria",
-        "7": "Especialización",
-        "8": "Maestría",
-        "9": "Doctorado"
+        "1": "Ninguno",
+        "2": "Preescolar",
+        "3": "Básica primaria (1o - 5o)",
+        "4": "Básica secundaria (6o - 9o)",
+        "5": "Media académica (Bachillerato clásico)",
+        "6": "Media técnica (Bachillerato técnico)",
+        "7": "Normalista",
+        "8": "Técnica profesional",
+        "9": "Tecnológica",
+        "10": "Universitaria",
+        "11": "Especialización",
+        "12": "Maestría",
+        "13": "Doctorado",
+        "99": "No sabe, no informa"
       },
-      "comparability_warning": "Código cambia de P6210 (marco 2005) a P3042 (marco 2018). Las categorías fueron ampliadas en el rediseño de 2021 (de 9 a 13 opciones observadas). Requiere tabla de equivalencias para comparación entre épocas.",
+      "comparability_warning": "Código cambia de P6210 (marco 2005) a P3042 (marco 2018). GEIH-1 (P6210) usa 9 categorías con codificación diferente (1=Ninguno/Preescolar, 2=Primaria, 3=Secundaria, 4=Media, 5=Técnica/Tecnológica, 6=Universitaria, 7=Especialización, 8=Maestría, 9=Doctorado). GEIH-2 (P3042) usa 13 categorías con mayor granularidad según DANE catálogo 819, variable F63 (P3042). Las categorías NO son directamente comparables entre épocas: requiere tabla de equivalencias GEIH-1→GEIH-2 para análisis longitudinal.",
       "mappings": {
         "geih_2006_2020": {
           "source_variable": "P6210",
@@ -594,7 +602,8 @@
         "1": "A término fijo",
         "2": "A término indefinido",
         "3": "Obra o labor contratada",
-        "4": "Otro tipo de contrato"
+        "4": "Otro tipo de contrato",
+        "9": "No sabe / No informa"
       },
       "comparability_warning": null,
       "mappings": {


### PR DESCRIPTION
## Summary

Three domain gaps in `variable_map.json` were discovered during end-to-end testing against real DANE 2024-06 microdata. All fixes are data-only (`variable_map.json` + notes); no code changes.

- **`educ_max`**: Replaced the 9 GEIH-1 (P6210) categories with the 13 official DANE GEIH-2 categories for P3042, verified against [DANE catálogo 819, variable F63](https://microdatos.dane.gov.co/index.php/catalog/819/variable/F63/V4044?name=P3042). Added code 99 ("No sabe, no informa"). Updated `comparability_warning` to document that GEIH-1 and GEIH-2 codifications are NOT directly comparable and require a crosswalk table.

- **`parentesco_jefe`**: Extended domain to include codes 11 (10 persons), 12 (4 persons), and 13 (780 persons) observed in June 2024 data. Labels are conservative best-guesses; `comparability_warning` explicitly flags them as **requiring human verification** against the DANE GEIH-2 questionnaire PDF.

- **`tipo_contrato`**: Added code 9 ("No sabe / No informa") observed in June 2024 data (7 persons). Standard DANE convention.

## Out of scope

`vivienda_propia` and `ingreso_total` are **not** in this PR. Their `module` field in `variable_map.json` is already correct. The problem — `load_merged` not auto-including the required modules — is a Builder/code issue tracked in #14.

## Validation

```
python scripts/validate_sources.py   # → 3 ✅
pytest -v                            # → 134 passed, 14 skipped
```

Closes #11, Closes #13.