### PR TITLE
Phase 2 debt: load_merged validation + auto-inclusion

### DIFF
--- a/PHASE_2_CODE_NOTES.md
+++ b/PHASE_2_CODE_NOTES.md
@@ -185,3 +185,47 @@ as float64-with-NaN now harmonize without raising or being skipped.
 ("1", "2") instead of the original dtype (1.0, 2.0). This is the correct canonical
 form for categoricals. See `test_categorical_validation_passes_for_valid_codes`
 (updated).
+
+---
+
+## Phase 2 Debt — Module Validation & Auto-Inclusion (PR #16)
+
+### Validation
+
+`load_merged()` now validates every module in the `modules` parameter against
+`sources.json` before any loading begins. Invalid module names raise
+`ModuleNotAvailableError` immediately instead of being silently skipped by the
+`if mod in record["modules"]` filter. This mirrors the existing behaviour of
+`load()` (single-module).
+
+### Auto-inclusion
+
+A new private helper `_required_modules_for_variables(variable_map, sources,
+epoch_key, requested_variables)` computes the set of modules required by
+canonical variables for a given epoch. It filters to modules that (a) appear in
+`sources["modules"]` and (b) list the epoch in their `available_in` field, so
+epoch-specific modules are not accidentally requested for the wrong epoch.
+
+When `harmonize=True` and the user provides an explicit `modules` list,
+`load_merged()` calls this helper and appends any missing required modules to
+the working list. Auto-included modules are logged at `DEBUG` level
+(`pulso._core.loader` logger) for traceability without noisy warnings.
+
+This means a user calling:
+
+```python
+pulso.load_merged(year=2024, month=6,
+                  modules=["caracteristicas_generales", "ocupados",
+                           "desocupados", "inactivos"],
+                  harmonize=True)
+```
+
+now gets `vivienda_propia` (from `vivienda_hogares`) and `ingreso_total` (from
+`otros_ingresos`) in the output without needing to name those modules explicitly.
+
+When `harmonize=False`, the user's exact module list is respected (no
+auto-inclusion). The `modules=None` case is unchanged: it falls back to
+`list(record["modules"].keys())`, which already includes all modules registered
+for that period.
+
+### Closes Issue #12

--- a/pulso/_core/loader.py
+++ b/pulso/_core/loader.py
@@ -5,12 +5,52 @@ Coordinates: registry lookup → download → parse → harmonize → (merge).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+import logging
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     import pandas as pd
 
 Area = Literal["cabecera", "resto", "total"]
+
+logger = logging.getLogger(__name__)
+
+
+def _required_modules_for_variables(
+    variable_map: dict[str, Any],
+    sources: dict[str, Any],
+    epoch_key: str,
+    requested_variables: list[str] | None = None,
+) -> set[str]:
+    """Return modules required by canonical variables for this epoch.
+
+    Only includes modules listed in sources["modules"] that have epoch_key in
+    their available_in list. Variables without a mapping for epoch_key are
+    silently skipped.
+    """
+    epoch_modules: set[str] = {
+        name
+        for name, meta in sources["modules"].items()
+        if epoch_key in meta.get("available_in", [])
+    }
+
+    required: set[str] = set()
+    variables_dict: dict[str, Any] = variable_map["variables"]
+    target_vars = (
+        requested_variables if requested_variables is not None else list(variables_dict.keys())
+    )
+
+    for var_name in target_vars:
+        entry = variables_dict.get(var_name)
+        if not entry:
+            continue
+        if epoch_key not in entry.get("mappings", {}):
+            continue
+        module = entry.get("module")
+        if module and module in epoch_modules:
+            required.add(module)
+
+    return required
 
 
 def load(
@@ -156,13 +196,20 @@ def load_merged(
     import pandas as pd
 
     from pulso._config.epochs import epoch_for_month
-    from pulso._config.registry import _load_sources
+    from pulso._config.registry import _load_sources, _load_variable_map
     from pulso._core.harmonizer import harmonize_dataframe
     from pulso._core.merger import merge_modules
-    from pulso._utils.validation import validate_year_month
+    from pulso._utils.validation import validate_module, validate_year_month
 
     periods = validate_year_month(year, month)
     sources = _load_sources()
+
+    # Issue 1: validate all user-specified modules against the global registry
+    # upfront so invalid names raise immediately instead of being silently skipped.
+    if modules is not None:
+        all_known_modules = list(sources["modules"].keys())
+        for mod in modules:
+            validate_module(mod, all_known_modules)
 
     all_frames: list[pd.DataFrame] = []
     multi = len(periods) > 1
@@ -181,7 +228,20 @@ def load_merged(
                 hint="Use pulso.list_available() to see which months are in the registry.",
             )
 
-        available_modules = modules if modules is not None else list(record["modules"].keys())
+        # Determine the working module list for this period.
+        working_modules = list(record["modules"].keys()) if modules is None else list(modules)
+
+        # Issue 2: when harmonize=True and the user provided an explicit module
+        # list, auto-include any modules required by the canonical variables so
+        # harmonization doesn't silently skip variables whose source columns are
+        # absent.  Only applies when harmonize=True; user's list is sacred otherwise.
+        if harmonize and modules is not None:
+            variable_map = _load_variable_map()
+            required = _required_modules_for_variables(variable_map, sources, epoch.key, variables)
+            for m in required:
+                if m not in working_modules:
+                    working_modules.append(m)
+                    logger.debug("Auto-including module %r required by harmonized variables.", m)
 
         module_dfs = {
             mod: load(
@@ -194,7 +254,7 @@ def load_merged(
                 show_progress=show_progress,
                 allow_unvalidated=allow_unvalidated,
             )
-            for mod in available_modules
+            for mod in working_modules
             if mod in record["modules"]
         }
 

--- a/tests/integration/test_harmonize_fixture.py
+++ b/tests/integration/test_harmonize_fixture.py
@@ -76,9 +76,9 @@ def test_load_merged_condicion_actividad_classifies_correctly(
     ca = df["condicion_actividad"].dropna()
 
     # All values must be in {"1", "2", "3"}
-    assert set(ca.unique()).issubset({"1", "2", "3"}), (
-        f"Unexpected condicion_actividad values: {set(ca.unique())}"
-    )
+    assert set(ca.unique()).issubset(
+        {"1", "2", "3"}
+    ), f"Unexpected condicion_actividad values: {set(ca.unique())}"
 
     # Fixture has 30 ocupados (OCI=1), 6 desocupados (DSI=1), 14 inactivos (DSI=NaN)
     counts = ca.value_counts()
@@ -129,3 +129,43 @@ def test_load_merged_returns_persona_level_unique_keys(
         f"Expected {df.shape[0]} unique persona keys, got {n_unique}. "
         "The merge produced duplicate rows."
     )
+
+
+@pytest.mark.integration
+def test_load_merged_raises_on_invalid_module(
+    registry_with_unified_fixture: None,
+) -> None:
+    """ModuleNotAvailableError is raised for an invalid module name, not silently skipped."""
+    import pulso
+    from pulso._utils.exceptions import ModuleNotAvailableError
+
+    with pytest.raises(ModuleNotAvailableError):
+        pulso.load_merged(
+            year=2024,
+            month=6,
+            modules=["caracteristicas_generales", "ocupados", "no_ocupados", "nonexistent_module"],
+            harmonize=False,
+        )
+
+
+@pytest.mark.integration
+def test_load_merged_auto_includes_required_modules_with_real_data() -> None:
+    """Auto-inclusion works against real DANE data: vivienda_hogares is added for vivienda_propia.
+
+    Requires the 2024-06 DANE ZIP to be cached locally (--run-integration).
+    """
+    import pulso
+
+    # User specifies only person-level modules; vivienda_hogares is NOT in the list.
+    # When harmonize=True, vivienda_hogares should be auto-included so that
+    # vivienda_propia is harmonized instead of silently skipped.
+    df = pulso.load_merged(
+        year=2024,
+        month=6,
+        modules=["caracteristicas_generales", "ocupados", "desocupados", "inactivos"],
+        harmonize=True,
+    )
+
+    assert (
+        "vivienda_propia" in df.columns
+    ), "vivienda_propia missing — vivienda_hogares was not auto-included"

--- a/tests/integration/test_harmonize_fixture.py
+++ b/tests/integration/test_harmonize_fixture.py
@@ -76,9 +76,9 @@ def test_load_merged_condicion_actividad_classifies_correctly(
     ca = df["condicion_actividad"].dropna()
 
     # All values must be in {"1", "2", "3"}
-    assert set(ca.unique()).issubset(
-        {"1", "2", "3"}
-    ), f"Unexpected condicion_actividad values: {set(ca.unique())}"
+    assert set(ca.unique()).issubset({"1", "2", "3"}), (
+        f"Unexpected condicion_actividad values: {set(ca.unique())}"
+    )
 
     # Fixture has 30 ocupados (OCI=1), 6 desocupados (DSI=1), 14 inactivos (DSI=NaN)
     counts = ca.value_counts()
@@ -166,6 +166,6 @@ def test_load_merged_auto_includes_required_modules_with_real_data() -> None:
         harmonize=True,
     )
 
-    assert (
-        "vivienda_propia" in df.columns
-    ), "vivienda_propia missing — vivienda_hogares was not auto-included"
+    assert "vivienda_propia" in df.columns, (
+        "vivienda_propia missing — vivienda_hogares was not auto-included"
+    )

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1,0 +1,285 @@
+"""Unit tests for pulso._core.loader: module validation and auto-inclusion."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from pulso._utils.exceptions import ModuleNotAvailableError
+
+# ---------------------------------------------------------------------------
+# Shared test data
+# ---------------------------------------------------------------------------
+
+_EPOCH_KEY = "geih_2021_present"
+
+_MINIMAL_SOURCES: dict[str, Any] = {
+    "metadata": {"schema_version": "1.1.0", "data_version": "2026.04"},
+    "modules": {
+        "caracteristicas_generales": {
+            "level": "persona",
+            "description_es": "CG",
+            "description_en": "CG",
+            "available_in": [_EPOCH_KEY],
+        },
+        "ocupados": {
+            "level": "persona",
+            "description_es": "Ocu",
+            "description_en": "Ocu",
+            "available_in": [_EPOCH_KEY],
+        },
+        "vivienda_hogares": {
+            "level": "hogar",
+            "description_es": "Viv",
+            "description_en": "Viv",
+            "available_in": [_EPOCH_KEY],
+        },
+    },
+    "data": {
+        "2024-06": {
+            "epoch": _EPOCH_KEY,
+            "download_url": "https://example.com/fake.zip",
+            "checksum_sha256": "abc",
+            "validated": True,
+            "modules": {
+                "caracteristicas_generales": {"file": "CSV/cg.CSV"},
+                "ocupados": {"file": "CSV/ocu.CSV"},
+                "vivienda_hogares": {"file": "CSV/viv.CSV"},
+            },
+        }
+    },
+}
+
+_MINIMAL_VARIABLE_MAP: dict[str, Any] = {
+    "metadata": {"schema_version": "1.0.0"},
+    "variables": {
+        "vivienda_propia": {
+            "type": "boolean",
+            "level": "vivienda",
+            "module": "vivienda_hogares",
+            "mappings": {
+                _EPOCH_KEY: {
+                    "source_variable": "P5090",
+                    "transform": {"op": "compute", "expr": "P5090 <= 2"},
+                }
+            },
+        },
+        "edad": {
+            "type": "numeric",
+            "level": "persona",
+            "module": "caracteristicas_generales",
+            "mappings": {
+                _EPOCH_KEY: {
+                    "source_variable": "P6040",
+                    "transform": "identity",
+                }
+            },
+        },
+    },
+}
+
+
+def _minimal_df() -> pd.DataFrame:
+    return pd.DataFrame({"DIRECTORIO": ["1"], "SECUENCIA_P": ["1"], "ORDEN": ["1"]})
+
+
+# ---------------------------------------------------------------------------
+# _required_modules_for_variables — pure-function tests
+# ---------------------------------------------------------------------------
+
+
+def test_required_modules_returns_all_modules_for_epoch() -> None:
+    from pulso._core.loader import _required_modules_for_variables
+
+    result = _required_modules_for_variables(_MINIMAL_VARIABLE_MAP, _MINIMAL_SOURCES, _EPOCH_KEY)
+    assert result == {"vivienda_hogares", "caracteristicas_generales"}
+
+
+def test_required_modules_filters_by_requested_variables() -> None:
+    from pulso._core.loader import _required_modules_for_variables
+
+    result = _required_modules_for_variables(
+        _MINIMAL_VARIABLE_MAP, _MINIMAL_SOURCES, _EPOCH_KEY, requested_variables=["edad"]
+    )
+    assert result == {"caracteristicas_generales"}
+    assert "vivienda_hogares" not in result
+
+
+def test_required_modules_skips_variable_without_epoch_mapping() -> None:
+    from pulso._core.loader import _required_modules_for_variables
+
+    vm: dict[str, Any] = {
+        "variables": {
+            "old_var": {
+                "module": "old_module",
+                "mappings": {"geih_2006_2020": {"source_variable": "X", "transform": "identity"}},
+            }
+        }
+    }
+    sources: dict[str, Any] = {"modules": {"old_module": {"available_in": ["geih_2006_2020"]}}}
+
+    result = _required_modules_for_variables(vm, sources, "geih_2021_present")
+    assert "old_module" not in result
+
+
+def test_required_modules_skips_module_not_in_sources() -> None:
+    from pulso._core.loader import _required_modules_for_variables
+
+    vm: dict[str, Any] = {
+        "variables": {
+            "some_var": {
+                "module": "phantom_module",
+                "mappings": {_EPOCH_KEY: {"source_variable": "X", "transform": "identity"}},
+            }
+        }
+    }
+    sources: dict[str, Any] = {"modules": {}}
+
+    result = _required_modules_for_variables(vm, sources, _EPOCH_KEY)
+    assert "phantom_module" not in result
+
+
+# ---------------------------------------------------------------------------
+# load_merged: module validation (Issue 1)
+# ---------------------------------------------------------------------------
+
+
+def test_load_merged_raises_on_invalid_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid module names raise ModuleNotAvailableError before any loading."""
+    import pulso
+    import pulso._config.registry as reg
+
+    monkeypatch.setattr(reg, "_SOURCES", _MINIMAL_SOURCES)
+
+    with pytest.raises(ModuleNotAvailableError):
+        pulso.load_merged(year=2024, month=6, modules=["no_ocupados"])
+
+
+def test_load_merged_valid_modules_pass_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Valid module names pass validation; no ModuleNotAvailableError is raised."""
+    import pulso
+    import pulso._config.registry as reg
+    import pulso._core.loader as loader_mod
+    import pulso._core.merger as merger_mod
+
+    monkeypatch.setattr(reg, "_SOURCES", _MINIMAL_SOURCES)
+    monkeypatch.setattr(reg, "_VARIABLE_MAP", _MINIMAL_VARIABLE_MAP)
+    monkeypatch.setattr(loader_mod, "load", lambda *a, **kw: _minimal_df())
+    monkeypatch.setattr(merger_mod, "merge_modules", lambda *a, **kw: _minimal_df())
+
+    df = pulso.load_merged(
+        year=2024, month=6, modules=["caracteristicas_generales"], harmonize=False
+    )
+    assert df is not None
+
+
+# ---------------------------------------------------------------------------
+# load_merged: auto-inclusion (Issue 2)
+# ---------------------------------------------------------------------------
+
+
+def test_load_merged_auto_includes_required_modules_when_harmonize_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When harmonize=True and user provides explicit modules, required modules are auto-included."""
+    import pulso
+    import pulso._config.registry as reg
+    import pulso._core.harmonizer as harm_mod
+    import pulso._core.loader as loader_mod
+    import pulso._core.merger as merger_mod
+
+    monkeypatch.setattr(reg, "_SOURCES", _MINIMAL_SOURCES)
+    monkeypatch.setattr(reg, "_VARIABLE_MAP", _MINIMAL_VARIABLE_MAP)
+
+    loaded_modules: list[str] = []
+
+    def fake_load(year: int, month: int, module: str, **kwargs: Any) -> pd.DataFrame:
+        loaded_modules.append(module)
+        return _minimal_df()
+
+    monkeypatch.setattr(loader_mod, "load", fake_load)
+    monkeypatch.setattr(merger_mod, "merge_modules", lambda *a, **kw: _minimal_df())
+    monkeypatch.setattr(harm_mod, "harmonize_dataframe", lambda df, *a, **kw: df)
+
+    # User specifies only caracteristicas_generales — vivienda_hogares is NOT in list.
+    pulso.load_merged(
+        year=2024,
+        month=6,
+        modules=["caracteristicas_generales"],
+        harmonize=True,
+    )
+
+    # vivienda_propia requires vivienda_hogares → must be auto-included.
+    assert "vivienda_hogares" in loaded_modules
+
+
+def test_load_merged_no_auto_inclusion_when_harmonize_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When harmonize=False, user's exact module list is respected; no auto-inclusion."""
+    import pulso
+    import pulso._config.registry as reg
+    import pulso._core.loader as loader_mod
+    import pulso._core.merger as merger_mod
+
+    monkeypatch.setattr(reg, "_SOURCES", _MINIMAL_SOURCES)
+    monkeypatch.setattr(reg, "_VARIABLE_MAP", _MINIMAL_VARIABLE_MAP)
+
+    loaded_modules: list[str] = []
+
+    def fake_load(year: int, month: int, module: str, **kwargs: Any) -> pd.DataFrame:
+        loaded_modules.append(module)
+        return _minimal_df()
+
+    monkeypatch.setattr(loader_mod, "load", fake_load)
+    monkeypatch.setattr(merger_mod, "merge_modules", lambda *a, **kw: _minimal_df())
+
+    pulso.load_merged(
+        year=2024,
+        month=6,
+        modules=["caracteristicas_generales"],
+        harmonize=False,
+    )
+
+    assert "vivienda_hogares" not in loaded_modules
+    assert loaded_modules == ["caracteristicas_generales"]
+
+
+def test_load_merged_auto_inclusion_restricted_by_variables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When variables=[edad], only modules needed for edad are auto-included."""
+    import pulso
+    import pulso._config.registry as reg
+    import pulso._core.harmonizer as harm_mod
+    import pulso._core.loader as loader_mod
+    import pulso._core.merger as merger_mod
+
+    monkeypatch.setattr(reg, "_SOURCES", _MINIMAL_SOURCES)
+    monkeypatch.setattr(reg, "_VARIABLE_MAP", _MINIMAL_VARIABLE_MAP)
+
+    loaded_modules: list[str] = []
+
+    def fake_load(year: int, month: int, module: str, **kwargs: Any) -> pd.DataFrame:
+        loaded_modules.append(module)
+        return _minimal_df()
+
+    monkeypatch.setattr(loader_mod, "load", fake_load)
+    monkeypatch.setattr(merger_mod, "merge_modules", lambda *a, **kw: _minimal_df())
+    monkeypatch.setattr(harm_mod, "harmonize_dataframe", lambda df, *a, **kw: df)
+
+    # User requests only edad; edad only needs caracteristicas_generales.
+    pulso.load_merged(
+        year=2024,
+        month=6,
+        modules=["ocupados"],
+        harmonize=True,
+        variables=["edad"],
+    )
+
+    assert "caracteristicas_generales" in loaded_modules
+    assert "vivienda_hogares" not in loaded_modules


### PR DESCRIPTION
## Summary

- **Fix 1 (validation):** `load_merged()` now validates every module in the `modules` parameter against `sources.json` before any loading. Invalid names raise `ModuleNotAvailableError` immediately instead of being silently skipped by the `if mod in record["modules"]` filter. Mirrors the existing behaviour of `load()`.
- **Fix 2 (auto-inclusion):** When `harmonize=True` and the user provides an explicit `modules` list, `load_merged()` automatically appends any modules required by the canonical variables that would otherwise be missing. This ensures variables like `vivienda_propia` (needs `vivienda_hogares`) and `ingreso_total` (needs `otros_ingresos`) are harmonized rather than silently skipped. When `harmonize=False`, the user's exact list is respected.

## What changed

- `pulso/_core/loader.py`: added `_required_modules_for_variables()` helper + validation loop + auto-inclusion block in `load_merged()`
- `tests/unit/test_loader.py` (new): 9 unit tests covering the helper function and both fixes
- `tests/integration/test_harmonize_fixture.py`: 2 new integration tests (fixture-based validation error + real-data auto-inclusion)
- `PHASE_2_CODE_NOTES.md`: Phase 2 Debt section documenting both fixes

## Test results

```
142 passed, 16 skipped (integration, need --run-integration), 1 error (pre-existing: mocker not installed)
```

All existing tests pass. New unit tests pass. Integration tests skipped pending `--run-integration`.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)