### PR TITLE
data(sources): fix vivienda_hogares filename

### DIFF
--- a/pulso/data/sources.json
+++ b/pulso/data/sources.json
@@ -81,7 +81,7 @@
           "file": "CSV/No ocupados.CSV"
         },
         "vivienda_hogares": {
-          "file": "CSV/Vivienda y Hogares.CSV"
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
         },
         "otros_ingresos": {
           "file": "CSV/Otros ingresos e impuestos.CSV"


### PR DESCRIPTION
Fixes filename for vivienda_hogares in 2024-06 entry.

Was: 'CSV/Vivienda y Hogares.CSV'
Now: 'CSV/Datos del hogar y la vivienda.CSV' (verified against actual ZIP contents via zipfile.namelist())

NOTE: This PR alone does NOT make vivienda_propia harmonize end-to-end, because the merger has a separate bug (Issue #18 to be fixed by Builder) where it can't merge hogar-level modules with persona-level modules. Both PRs needed for full vivienda_propia + ingreso_total functionality.

Closes #17