### PR TITLE
Phase 2 debt: merger supports multi-level (persona + hogar)

### DIFF
--- a/PHASE_2_CODE_NOTES.md
+++ b/PHASE_2_CODE_NOTES.md
@@ -229,3 +229,40 @@ auto-inclusion). The `modules=None` case is unchanged: it falls back to
 for that period.
 
 ### Closes Issue #12
+
+---
+
+## Phase 2 Debt — Multi-level Merger
+
+### Bug
+`merge_modules()` previously assumed all modules were persona-level. Including a hogar-level
+module like `vivienda_hogares` triggered `MergeError: missing merge keys ['ORDEN']`.
+
+### Fix
+Merger now auto-detects each module's level by inspecting which merge_keys it has.
+
+- **`_detect_module_level(df, epoch)`**: returns `"persona"` if ORDEN is present; `"hogar"` if
+  HOGAR is present (without ORDEN); raises `MergeError` otherwise.
+- **`_merge_within_level(dfs_dict, keys, how)`**: extracted helper that merges a dict of same-level
+  DataFrames on the given keys, deduplicating shared non-key columns (same logic as before).
+
+When `level="persona"` (default):
+1. Auto-detect each module as persona or hogar
+2. Merge all persona-level modules together (outer join on DIRECTORIO, SECUENCIA_P, ORDEN)
+3. Merge all hogar-level modules together (outer join on DIRECTORIO, SECUENCIA_P, HOGAR)
+4. LEFT JOIN persona ⟕ hogar on [DIRECTORIO, SECUENCIA_P, HOGAR]
+
+This propagates hogar/vivienda info to each person in that household.
+
+When `level="hogar"` (legacy): all modules are forced to merge on hogar keys (no ORDEN required);
+backward-compatible with existing callers.
+
+### Backward Compatibility
+Persona-only merges produce identical results — all modules detected as "persona", merged as
+before. The `level="hogar"` path is unchanged (legacy behavior preserved so existing tests pass).
+
+### Tests Added
+- `test_detect_persona_level`, `test_detect_hogar_level`: unit tests for the detector
+- `test_merge_persona_and_hogar_propagates_hogar_info`: verifies hogar info propagates to persons
+- `test_existing_persona_only_merge_still_works`: backward compat guard
+- `test_load_merged_hogar_module_propagates_info`: integration test with synthetic fixture

--- a/pulso/_core/merger.py
+++ b/pulso/_core/merger.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 
 from pulso._utils.exceptions import MergeError
 
@@ -10,6 +10,48 @@ if TYPE_CHECKING:
     import pandas as pd
 
     from pulso._config.epochs import Epoch
+
+
+def _detect_module_level(df: pd.DataFrame, epoch: Epoch) -> Literal["persona", "hogar"]:
+    """Auto-detect module level by inspecting which merge keys are present.
+
+    Returns "persona" if all persona keys (including ORDEN) are present.
+    Returns "hogar" if hogar base keys and a HOGAR column are present.
+
+    Raises:
+        MergeError: If the module lacks sufficient keys for either level.
+    """
+    persona_keys = list(epoch.merge_keys_persona)
+    hogar_base_keys = list(epoch.merge_keys_hogar)
+
+    if all(k in df.columns for k in persona_keys):
+        return "persona"
+    if all(k in df.columns for k in hogar_base_keys) and "HOGAR" in df.columns:
+        return "hogar"
+    raise MergeError(
+        f"Module is missing merge keys: expected {persona_keys} (persona level) "
+        f"or {[*hogar_base_keys, 'HOGAR']} (hogar level). "
+        f"Got columns: {df.columns.tolist()[:10]}"
+    )
+
+
+def _merge_within_level(
+    dfs_dict: dict[str, pd.DataFrame],
+    keys: list[str],
+    how: str,
+) -> pd.DataFrame | None:
+    """Merge multiple DataFrames on the same keys, deduplicating shared non-key columns."""
+    if not dfs_dict:
+        return None
+    items = list(dfs_dict.items())
+    _, merged = items[0]
+    merged = merged.copy()
+    for _, df in items[1:]:
+        existing_non_key = set(merged.columns) - set(keys)
+        cols_to_drop = [c for c in df.columns if c in existing_non_key]
+        df_to_merge = df.drop(columns=cols_to_drop) if cols_to_drop else df
+        merged = merged.merge(df_to_merge, on=keys, how=how)
+    return cast("pd.DataFrame", merged)
 
 
 def merge_modules(
@@ -23,7 +65,12 @@ def merge_modules(
     Args:
         module_dfs: {module_name: DataFrame} — at least one entry required.
         epoch: Epoch object providing merge_keys_persona / merge_keys_hogar.
-        level: "persona" uses all three persona keys; "hogar" drops ORDEN.
+        level: Output level. "persona" (default) auto-detects each module's
+            level and performs a multi-level merge: persona modules are merged
+            together, hogar modules are merged together, then the hogar result
+            is LEFT JOINed into persona on [DIRECTORIO, SECUENCIA_P, HOGAR].
+            "hogar" uses legacy behavior: all modules merged on hogar keys
+            (ORDEN not required), useful for hogar-level-only operations.
         how: pandas merge strategy ("outer" is the default so condicion_actividad
              works correctly — persons can appear in only one of ocupados /
              no_ocupados).
@@ -40,34 +87,50 @@ def merge_modules(
     if not module_dfs:
         raise MergeError("merge_modules called with empty module_dfs.")
 
-    if level == "persona":
-        keys = list(epoch.merge_keys_persona)
-    elif level == "hogar":
+    if level == "hogar":
+        # Legacy behavior: all modules merged on hogar keys (ORDEN not required).
         keys = list(epoch.merge_keys_hogar)
-    else:
+        for name, df in module_dfs.items():
+            missing = [k for k in keys if k not in df.columns]
+            if missing:
+                raise MergeError(
+                    f"Module {name!r} is missing merge keys {missing}. "
+                    f"Required for level={level!r} merge."
+                )
+        result = _merge_within_level(module_dfs, keys, how)
+        assert result is not None  # module_dfs is non-empty
+        return result
+
+    if level != "persona":
         raise MergeError(f"Unknown merge level {level!r}. Expected 'persona' or 'hogar'.")
 
+    # level == "persona": auto-detect each module's level, then merge across levels.
+    by_level: dict[str, dict[str, pd.DataFrame]] = {"persona": {}, "hogar": {}}
     for name, df in module_dfs.items():
-        missing = [k for k in keys if k not in df.columns]
+        detected = _detect_module_level(df, epoch)
+        by_level[detected][name] = df
+
+    persona_keys = list(epoch.merge_keys_persona)
+    hogar_base_keys = list(epoch.merge_keys_hogar)
+    hogar_join_keys = [*hogar_base_keys, "HOGAR"]
+
+    persona_merged = _merge_within_level(by_level["persona"], persona_keys, how)
+    hogar_merged = _merge_within_level(by_level["hogar"], hogar_join_keys, how)
+
+    if persona_merged is None:
+        raise MergeError("Cannot produce persona-level output: no persona-level modules provided.")
+
+    result = persona_merged
+    if hogar_merged is not None:
+        missing = [k for k in hogar_join_keys if k not in result.columns]
         if missing:
             raise MergeError(
-                f"Module {name!r} is missing merge keys {missing}. "
-                f"Required for level={level!r} merge."
+                f"Persona-level merged DataFrame is missing hogar join keys: {missing}"
             )
+        # Drop from hogar_merged any non-join columns already present in persona (keep persona's)
+        existing_non_join = set(result.columns) - set(hogar_join_keys)
+        cols_to_drop = [c for c in hogar_merged.columns if c in existing_non_join]
+        hogar_to_merge = hogar_merged.drop(columns=cols_to_drop) if cols_to_drop else hogar_merged
+        result = result.merge(hogar_to_merge, on=hogar_join_keys, how="left")
 
-    items = list(module_dfs.items())
-    _, merged = items[0]
-    merged = merged.copy()
-
-    for _name, df in items[1:]:
-        # Drop columns from the incoming module that already exist in merged
-        # (except merge keys, which are required for the join itself).
-        # This prevents suffix-polluted columns for shared identifiers like
-        # CLASE, DPTO, FEX_C18, MES that carry the same value in every module.
-        existing_non_key = set(merged.columns) - set(keys)
-        cols_to_drop = [c for c in df.columns if c in existing_non_key]
-        df_to_merge = df.drop(columns=cols_to_drop) if cols_to_drop else df
-
-        merged = merged.merge(df_to_merge, on=keys, how=how)
-
-    return merged
+    return result

--- a/tests/integration/test_harmonize_fixture.py
+++ b/tests/integration/test_harmonize_fixture.py
@@ -12,7 +12,15 @@ Run with:
 
 from __future__ import annotations
 
+import hashlib
+import io
+import zipfile
+from typing import TYPE_CHECKING, Any
+
 import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.mark.integration
@@ -169,3 +177,157 @@ def test_load_merged_auto_includes_required_modules_with_real_data() -> None:
     assert "vivienda_propia" in df.columns, (
         "vivienda_propia missing — vivienda_hogares was not auto-included"
     )
+
+
+# ─── Multi-level merge integration ───────────────────────────────────
+
+
+_SEP = ";"
+_DECIMAL = ","
+_N = 10
+
+
+def _df_to_bytes_local(df: Any) -> bytes:
+    import pandas as pd
+
+    buf = io.BytesIO()
+    pd.DataFrame(df).to_csv(buf, index=False, sep=_SEP, decimal=_DECIMAL, encoding="utf-8")
+    return buf.getvalue()
+
+
+def _build_multilevel_zip() -> tuple[bytes, str]:
+    """Build an in-memory ZIP with persona (caracteristicas_generales) and hogar (vivienda_hogares).
+
+    Returns (zip_bytes, sha256_hex).
+    """
+    import pandas as pd
+
+    carac = pd.DataFrame(
+        {
+            "DIRECTORIO": [f"{i:05d}" for i in range(1, _N + 1)],
+            "SECUENCIA_P": [1] * _N,
+            "ORDEN": [1] * _N,
+            "HOGAR": [1] * _N,
+            "CLASE": [1] * _N,
+            "P6040": list(range(20, 20 + _N)),
+            "FEX_C18": [1000.0] * _N,
+        }
+    )
+
+    vivienda = pd.DataFrame(
+        {
+            "DIRECTORIO": [f"{i:05d}" for i in range(1, _N + 1)],
+            "SECUENCIA_P": [1] * _N,
+            "HOGAR": [1] * _N,
+            "P5090": list(range(1, _N + 1)),
+        }
+    )
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "CSV/Características generales, seguridad social en salud y educación.CSV",
+            _df_to_bytes_local(carac),
+        )
+        zf.writestr("CSV/Vivienda y hogares.CSV", _df_to_bytes_local(vivienda))
+
+    zip_bytes = buf.getvalue()
+    sha256 = hashlib.sha256(zip_bytes).hexdigest()
+    return zip_bytes, sha256
+
+
+def _make_multilevel_sources(sha256: str) -> dict[str, Any]:
+    return {
+        "metadata": {
+            "schema_version": "1.1.0",
+            "data_version": "2026.04",
+            "last_updated": "2026-04-30T00:00:00Z",
+            "scraper_version": None,
+            "covered_range": ["2024-06", "2024-06"],
+        },
+        "modules": {
+            "caracteristicas_generales": {
+                "level": "persona",
+                "description_es": "Características generales",
+                "description_en": "General characteristics",
+                "available_in": ["geih_2021_present"],
+            },
+            "vivienda_hogares": {
+                "level": "hogar",
+                "description_es": "Vivienda y hogares",
+                "description_en": "Dwelling and households",
+                "available_in": ["geih_2021_present"],
+            },
+        },
+        "data": {
+            "2024-06": {
+                "epoch": "geih_2021_present",
+                "download_url": "https://example.com/fake_multilevel.zip",
+                "checksum_sha256": sha256,
+                "modules": {
+                    "caracteristicas_generales": {
+                        "file": (
+                            "CSV/Características generales, "
+                            "seguridad social en salud y educación.CSV"
+                        ),
+                    },
+                    "vivienda_hogares": {
+                        "file": "CSV/Vivienda y hogares.CSV",
+                    },
+                },
+                "validated": True,
+                "validated_by": "manual",
+                "validated_at": None,
+                "scraped_at": None,
+                "landing_page": None,
+                "size_bytes": None,
+                "notes": "Synthetic multi-level fixture for hogar merge tests",
+            }
+        },
+    }
+
+
+@pytest.fixture
+def registry_with_multilevel_fixture(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Inject a registry with persona + hogar modules sharing the same ZIP."""
+    import pulso._config.registry as reg
+
+    zip_bytes, sha256 = _build_multilevel_zip()
+
+    cache_root = tmp_path / "cache"
+    short = sha256[:16]
+    dest = cache_root / "raw" / "2024" / "06" / f"{short}.zip"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(zip_bytes)
+
+    monkeypatch.setenv("PULSO_CACHE_DIR", str(cache_root))
+    monkeypatch.setattr(reg, "_SOURCES", _make_multilevel_sources(sha256))
+
+
+@pytest.mark.integration
+def test_load_merged_hogar_module_propagates_info(
+    registry_with_multilevel_fixture: None,
+) -> None:
+    """vivienda_hogares (hogar-level) is merged with persona-level modules without error.
+
+    Hogar info (P5090) must be propagated to all persons in that household.
+    """
+    import pulso
+
+    df = pulso.load_merged(
+        year=2024,
+        month=6,
+        modules=["caracteristicas_generales", "vivienda_hogares"],
+        area="total",
+        harmonize=False,
+    )
+
+    assert df.shape[0] == _N, f"Expected {_N} rows, got {df.shape[0]}"
+    assert "DIRECTORIO" in df.columns
+    assert "ORDEN" in df.columns, "Persona key must be present"
+    assert "P6040" in df.columns, "Persona-level variable must be present"
+    assert "P5090" in df.columns, "Hogar-level variable must be propagated to all persons"
+    assert df["P5090"].notna().all(), "Every person must receive hogar info (left join)"

--- a/tests/unit/test_merger.py
+++ b/tests/unit/test_merger.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pandas as pd
 import pytest
 
-from pulso._core.merger import merge_modules
+from pulso._core.merger import _detect_module_level, merge_modules
 from pulso._utils.exceptions import MergeError
 
 
@@ -142,3 +142,58 @@ def test_merge_drops_duplicate_non_key_columns() -> None:
     assert "MOD1_VAR" in result.columns
     assert "MOD2_VAR" in result.columns
     assert "MOD3_VAR" in result.columns
+
+
+# ─── Multi-level merge tests ───────────────────────────────────────────
+
+
+def test_detect_persona_level() -> None:
+    df = pd.DataFrame({"DIRECTORIO": [1], "SECUENCIA_P": [1], "ORDEN": [1], "P3271": [1]})
+    assert _detect_module_level(df, _epoch()) == "persona"
+
+
+def test_detect_hogar_level() -> None:
+    df = pd.DataFrame({"DIRECTORIO": [1], "SECUENCIA_P": [1], "HOGAR": [1], "P5090": [1]})
+    assert _detect_module_level(df, _epoch()) == "hogar"
+
+
+def test_merge_persona_and_hogar_propagates_hogar_info() -> None:
+    """Hogar-level info is left-joined into all persons sharing that household."""
+    persona_df = pd.DataFrame(
+        {
+            "DIRECTORIO": [1, 1, 2],
+            "SECUENCIA_P": [1, 1, 1],
+            "ORDEN": [1, 2, 1],
+            "HOGAR": [1, 1, 1],
+            "P3271": [1, 2, 1],
+        }
+    )
+    hogar_df = pd.DataFrame(
+        {
+            "DIRECTORIO": [1, 2],
+            "SECUENCIA_P": [1, 1],
+            "HOGAR": [1, 1],
+            "P5090": [1, 3],
+        }
+    )
+    result = merge_modules({"persona": persona_df, "hogar": hogar_df}, _epoch(), level="persona")
+
+    assert len(result) == 3
+    assert "P5090" in result.columns
+    assert result.iloc[0]["P5090"] == 1
+    assert result.iloc[1]["P5090"] == 1
+    assert result.iloc[2]["P5090"] == 3
+
+
+def test_existing_persona_only_merge_still_works() -> None:
+    """Backward compatibility: persona-only merges produce identical results."""
+    df1 = pd.DataFrame(
+        {"DIRECTORIO": [1, 2], "SECUENCIA_P": [1, 1], "ORDEN": [1, 1], "X": [10, 20]}
+    )
+    df2 = pd.DataFrame(
+        {"DIRECTORIO": [1, 2], "SECUENCIA_P": [1, 1], "ORDEN": [1, 1], "Y": [30, 40]}
+    )
+    result = merge_modules({"a": df1, "b": df2}, _epoch(), level="persona")
+    assert len(result) == 2
+    assert "X" in result.columns
+    assert "Y" in result.columns


### PR DESCRIPTION
## Summary

- `merge_modules()` previously rejected hogar-level modules (e.g. `vivienda_hogares`) with `MergeError: missing merge keys ['ORDEN']` when called with `level="persona"`
- Merger now auto-detects each module's level by inspecting which keys are present (ORDEN → persona, HOGAR → hogar), then performs a multi-level merge: persona ⟕ hogar on [DIRECTORIO, SECUENCIA_P, HOGAR]
- `level="hogar"` retains the old behavior (all modules merged on hogar keys) for full backward compatibility — all 9 pre-existing tests pass unchanged

## Changes

- `pulso/_core/merger.py`: Add `_detect_module_level()`, `_merge_within_level()` helpers; rewrite `merge_modules()` level="persona" path for multi-level support
- `tests/unit/test_merger.py`: 4 new tests (`test_detect_persona_level`, `test_detect_hogar_level`, `test_merge_persona_and_hogar_propagates_hogar_info`, `test_existing_persona_only_merge_still_works`)
- `tests/integration/test_harmonize_fixture.py`: New self-contained integration test with synthetic fixture covering persona + hogar module load
- `PHASE_2_CODE_NOTES.md`: Document the bug, fix, and test coverage

## Test plan

- [x] `pytest -v` → 147 passed, 17 skipped (integration, need flag)
- [x] `pytest --run-integration tests/integration/test_harmonize_fixture.py -v` → 8 passed (including new hogar test)
- [x] `mypy pulso` → 0 new errors in merger.py (pre-existing errors in harmonizer unchanged)
- [x] `ruff check pulso tests scripts` → all checks passed
- [x] `ruff format --check pulso tests scripts` → all files formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)