### PR TITLE
Phase 3.1: DANE catalog scraping

### DIFF
--- a/docs/CATALOG_NOTES.md
+++ b/docs/CATALOG_NOTES.md
@@ -1,0 +1,262 @@
+# DANE GEIH Catalog Notes
+
+Phase 3.1 findings from scraping the DANE MERCLAB-Microdatos collection.
+Produced by `scripts/scrape_dane_catalog.py` on 2026-05-01.
+
+---
+
+## Scrape summary
+
+| Field | Value |
+|-------|-------|
+| **Scraped at** | 2026-05-01 |
+| **Annual catalogs visited** | 20 |
+| **GEIH monthly entries found** | 230 |
+| **Coverage span** | 2007-01 to 2026-02 |
+| **Total months covered** | 230 |
+| **Expected months (2007-01 → 2026-05)** | 233 |
+| **Gap count** | 3 (all in 2026, not yet published) |
+
+---
+
+## Coverage by year
+
+| Year | Months | Catalog ID | Size range (MB) | Notes |
+|------|--------|-----------|-----------------|-------|
+| 2007 | 12/12 | 317 | 6–7 | Earliest available microdata |
+| 2008 | 12/12 | 206 | 6–15 | |
+| 2009 | 12/12 | 207 | 6–6 | |
+| 2010 | 12/12 | 205 | 6–7 | |
+| 2011 | 12/12 | 182 | 7–7 | |
+| 2012 | 12/12 | 77 | 6–7 | |
+| 2013 | 12/12 | 68 | 6–7 | |
+| 2014 | 12/12 | 328 | 6–7 | |
+| 2015 | 12/12 | 356 | 6–7 | |
+| 2016 | 12/12 | 427 | 6–7 | |
+| 2017 | 12/12 | 458 | 6–9 | |
+| 2018 | 12/12 | 547 | 6–7 | |
+| 2019 | 12/12 | 599 | 6–7 | |
+| 2020 | 12/12 | 780 | 8–23 | COVID-19 reduced coverage Mar–Jul (see below) |
+| 2021 | 12/12 | 701 | 5–7 | Transitional year (Marco 2005 format retained) |
+| 2022 | 12/12 | 771 | 46–75 | **Major format change**: GEIH Marco 2018 deployed |
+| 2023 | 12/12 | 782 | 59–71 | |
+| 2024 | 12/12 | 819 | 55–66 | Sources.json anchor; 2024-06 validated |
+| 2025 | 12/12 | 853 | 59–66 | Full year available as of 2026-05 |
+| 2026 | 2/12 | 900 | 63–67 | Jan–Feb only; Mar–May not yet published |
+
+---
+
+## GEIH 2006: the microdata gap
+
+**The GEIH started field data collection on August 7, 2006** — but DANE has not
+published microdata for August–December 2006 in the MERCLAB portal.
+
+Evidence gathered during Phase 3.1:
+- The MERCLAB-Microdatos collection has no "GEIH 2006" catalog entry.
+- The earliest main annual GEIH catalog is **ID 317, titled "Gran Encuesta Integrada
+  de Hogares - GEIH 2007"**. Its `/get_microdata` page lists 12 files named
+  "Enero" through "Diciembre" (no year qualifier), all with upload dates of
+  2018-02-02 and file content clearly representing January–December 2007.
+- The catalog's own metadata says `Fecha inicio: 2007` for its data collection
+  period. The `idno` is `COL-DANE-GEIH-2007-IV-TRIMESTRE`, placing it in 2007.
+- Historical text within the catalog descriptions repeatedly references 2006
+  as the *start of operations* (e.g., "La recolección de la GEIH empezó el 7
+  de agosto de 2006"), not as data that is available for download.
+
+**Conclusion**: The 2006 microdata (Aug–Dec 2006, 5 months) was collected but is
+not published through the DANE microdata portal. The user community sometimes
+confuses **GEIH operational start (August 2006)** with **public microdata start
+(January 2007)**. For pulso, the effective earliest entry is **2007-01**.
+
+Phase 3.2 should set `covered_range` minimum to `"2007-01"` in `sources.json`
+metadata. If 2006 data becomes available, it would be in a separate catalog not
+yet present in MERCLAB.
+
+---
+
+## Identified gaps
+
+| Year | Month | Reason |
+|------|-------|--------|
+| 2026 | 03 | Not yet published (DANE publication lag ~2 months) |
+| 2026 | 04 | Not yet published (DANE publication lag ~2 months) |
+| 2026 | 05 | Not yet published (DANE publication lag ~2 months) |
+
+No months were completely absent for 2007–2025. The 2020 pandemic months
+(April–July 2020) **do exist** in the catalog — they have reduced file sizes
+reflecting smaller sample coverage, but the data files are present. See the
+2020 anomaly note below.
+
+---
+
+## Identified anomalies
+
+### 2020 COVID-19: reduced coverage March–July 2020
+
+DANE suspended in-person field operations in March 2020 and switched to
+telephone interviews for a subset of the sample. The monthly file sizes show
+this clearly:
+
+| Month | Size (MB) | Note |
+|-------|-----------|------|
+| Jan 2020 | 20.8 | Pre-COVID, full sample |
+| Feb 2020 | 20.8 | Pre-COVID, full sample |
+| Mar 2020 | 10.4 | **Partial** — lockdown mid-month |
+| Apr 2020 | 8.0 | **Reduced** — telephone-only interviews |
+| May 2020 | 11.7 | **Reduced** — telephone interviews |
+| Jun 2020 | 11.7 | **Reduced** — telephone interviews |
+| Jul 2020 | 11.6 | **Reduced** — telephone interviews |
+| Aug 2020 | 22.9 | Resumed, full sample |
+| Sep 2020 | 22.6 | Full sample |
+
+The data exists and downloads normally; coverage is simply reduced. Phase 3.2
+should flag these months with a note in `sources.json` so downstream users know
+to weight accordingly.
+
+### 2022 GEIH Marco 2018: major redesign
+
+Starting January 2022, DANE deployed the fully redesigned GEIH (Marco 2018 —
+using the 2018 Population and Housing Census as the sampling frame). This is
+visible as a dramatic size jump:
+
+- 2021-06 (old format): ~6 MB
+- 2022-06 (new format): ~67 MB — **11× larger**
+
+The 2022+ files also have a distinct naming convention:
+`GEIH_{Month}_{Year}_Marco_2018.zip` (though this shortened again in 2023+).
+The new survey adds expanded modules for migration, alternative work forms,
+and more socioeconomic variables. These align with the `geih_2021_present` epoch
+(though the true redesign boundary is 2022, not 2021 — see design note below).
+
+### Epoch boundary vs. survey redesign boundary
+
+The current `epochs.json` defines:
+- `geih_2006_2020`: covers 2006–2020
+- `geih_2021_present`: covers 2021 onwards
+
+However, the actual file format and survey design break at **2022, not 2021**:
+- 2021: Same ~5-7 MB CSV files as 2019–2020; same variable structure.
+  This was the "Sistema General de Pruebas" (testing phase) — new questionnaire
+  tested in parallel but published data is Marco 2005 format.
+- 2022: New Marco 2018 files, 46–75 MB, expanded modules.
+
+**Implication for Phase 3.2/3.3**: The variable harmonizer should treat 2021
+as behaviorally identical to the 2019–2020 era for file structure purposes,
+even though it's labeled `geih_2021_present`. The boundary where file structure
+truly changes is 2022-01. Flag this for the Builder team.
+
+### 2026 catalog: only 2 months
+
+Catalog 900 (GEIH 2026) was created anticipating the full year. Only January
+and February 2026 are published. This is expected — DANE typically publishes
+with a 2-month lag. March–May 2026 will be available by mid-2026.
+
+---
+
+## Catalog ID distribution
+
+| Stat | Value |
+|------|-------|
+| Earliest GEIH annual catalog ID | 68 (GEIH 2013) |
+| Lowest GEIH catalog ID found | 68 |
+| Highest GEIH catalog ID found | 900 (GEIH 2026) |
+| IDs are sequential by year? | **No** — IDs are assigned in upload order, not chronologically |
+| Range covered | 68–900 |
+| Non-GEIH catalogs in range | ~860 |
+
+Catalog ID 819 (GEIH 2024) was the known anchor from Phase 1. As a sanity
+check: this entry's download URL in `_scraped_catalog.json` matches exactly
+the URL in `sources.json` (`catalog/819/download/23625`). ✓
+
+---
+
+## Format observations
+
+### 2007–2021 (epoch `geih_2006_2020` + 2021)
+
+Each annual catalog contains multiple file formats per month. For example,
+2007 has for each month: the original SPSS file (no extension), a CSV ZIP,
+and sometimes a Stata DTA ZIP. By 2018, the set settled to SPSS + CSV + Stata
+for every month.
+
+The scraper selects **CSV format** as primary (`Enero.csv`, `Febrero.csv`, etc.)
+because pulso's core loader targets CSV input. For months where only SPSS or
+Stata is available (some 2007 entries), the SPSS file is selected.
+
+Auxiliary files in these catalogs (excluded by the scraper):
+- `Total_fact_exp_{YEAR}` / `Total_Fex_{YEAR}`: expansion factor files
+- `Fex proyecciones CNPV 2018_{YEAR}`: 2018 Census projection weights (added
+  retroactively to all years)
+- Various annual totals and methodology documentation ZIPs
+
+### 2022–2026 (epoch `geih_2021_present` from 2022)
+
+Single ZIP per month containing all survey modules as CSV files. File sizes
+are 55–79 MB. No auxiliary format variants — the CSV is the sole published format.
+File naming is less consistent than older years (trailing periods, underscores
+vs. spaces, month abbreviations like "Ene_2024").
+
+---
+
+## Discovery strategy: deviation from ADR 0004
+
+ADR 0004 described a sequential catalog-ID scanning strategy (start at ID 819,
+expand forward/backward, stop after 5 consecutive non-GEIH IDs). This was
+written before inspecting the live site.
+
+**Actual implementation**: The MERCLAB-Microdatos collection provides a paginated
+index of all surveys in DANE's labor-market catalog. Enumerating 9 pages (135
+catalog links) finds all GEIH catalogs in ~20 seconds, without scanning ~900
+individual IDs. The scraper then fetches each annual catalog's `/get_microdata`
+page to extract monthly file entries.
+
+This is faster, more reliable (no heuristic stop conditions), and more
+maintainable (DANE adding new surveys doesn't affect the scan). The committed
+`_scraped_catalog.json` captures the result for reproducibility.
+
+---
+
+## Open questions / human review needed
+
+1. **2006 microdata**: Confirm definitively whether DANE has Aug–Dec 2006 data
+   in any other system (e.g., the legacy ECH portal, or internal DANE requests).
+   If recoverable, it would require a new catalog entry type not currently modeled.
+
+2. **2021 epoch boundary**: The `geih_2021_present` epoch starts at 2021, but
+   the Marco 2018 redesign data starts at 2022. Should `epochs.json` be updated
+   to split 2021 into its own epoch, or is the current grouping acceptable for
+   harmonization? (Builder/Architect decision.)
+
+3. **2020 COVID months**: Should these have a `note` field in `sources.json`
+   flagging reduced coverage? Recommended: yes. Phase 3.2 should add a note to
+   April–July 2020 entries.
+
+4. **Primary file for 2007–2021**: The scraper selects CSV format. However, some
+   CSV ZIPs from this era may have different internal file structures than 2022+
+   (e.g., multiple sheets, different column names). Phase 3.3 (harmonizer) should
+   verify the first entry from each year range.
+
+---
+
+## Recommendations for Phase 3.2
+
+1. **Populate `sources.json`** with entries for all 230 months. The
+   `_scraped_catalog.json` provides all required fields: `download_url`,
+   `landing_page`, `size_bytes`, `epoch_inferred`.
+
+2. **Set `covered_range` to `["2007-01", "2026-02"]`** in `sources.json` metadata.
+   The commonly cited "August 2006" start is the survey inception, not the
+   earliest available microdata.
+
+3. **Mark 2024-06 as `validated: true`** (already in `sources.json` from Phase 1);
+   all other entries should start as `validated: false`.
+
+4. **Add `notes` field** to April–July 2020 entries documenting COVID-19 reduced
+   coverage.
+
+5. **Watch for 2026 updates**: Catalog 900 will gain March–May 2026 entries as
+   DANE publishes them. The scraper can be re-run to capture new months.
+
+6. **Check `checksum_sha256`**: Currently `null` for all entries — DANE does not
+   publish checksums on the get_microdata page. The validate step in Phase 3.2
+   should compute checksums after downloading a sample.

--- a/docs/adr/0004-dane-catalog-scraping.md
+++ b/docs/adr/0004-dane-catalog-scraping.md
@@ -1,0 +1,133 @@
+# ADR 0004: DANE Catalog Scraping Strategy
+
+## Status
+
+Accepted (Phase 3.1)
+
+## Context
+
+Phase 3 of pulso requires complete coverage of GEIH microdata from August 2006 to the current month (~230 monthly entries). To populate `pulso/data/sources.json` with all entries, we need a reliable, reproducible way to discover:
+
+1. Which months are available in the DANE catalog
+2. Each month's download URL
+3. Each month's checksum (when published)
+4. Each month's landing page (for human inspection)
+5. Any anomalies (missing months, format changes, special operatives like 2020-pandemia)
+
+Manual data entry is not viable at this scale and would not survive future months. We need automation.
+
+## Decision
+
+We will implement a Python script `scripts/scrape_dane_catalog.py` that:
+
+1. **Discovers DANE catalog URLs** by iterating known catalog ID ranges. DANE GEIH catalogs follow the pattern `https://microdatos.dane.gov.co/index.php/catalog/{ID}` where IDs are sequential integers. We start from a known anchor (catalog 819 = 2024-06 GEIH-2) and explore forward and backward.
+
+2. **Extracts metadata** from each catalog page using HTML parsing. Required fields:
+   - year, month
+   - download_url (the ZIP)
+   - checksum_sha256 (when DANE publishes one)
+   - size_bytes (from HTTP HEAD or page metadata)
+   - landing_page (the catalog URL itself)
+   - epoch_inferred (geih_2006_2020 or geih_2021_present, based on year)
+
+3. **Filters to GEIH-relevant catalogs only**. DANE publishes many surveys; we only want GEIH (Gran Encuesta Integrada de Hogares). Identification: title contains "Gran Encuesta Integrada de Hogares" and a month/year reference.
+
+4. **Outputs `pulso/data/_scraped_catalog.json`** with structure:
+
+```json
+   {
+     "scraped_at": "2026-05-01T00:00:00Z",
+     "scraped_by": "scripts/scrape_dane_catalog.py",
+     "schema_version": "0.1.0",
+     "entries": [
+       {
+         "year": 2024,
+         "month": 6,
+         "catalog_id": 819,
+         "download_url": "https://microdatos.dane.gov.co/...",
+         "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+         "checksum_sha256": "c5799177...",
+         "size_bytes": 66911109,
+         "epoch_inferred": "geih_2021_present",
+         "title": "...",
+         "anomalies": []
+       }
+     ],
+     "gaps": [
+       {"year": 2020, "month": 4, "reason": "DANE suspended operations due to pandemic"}
+     ],
+     "scrape_log": {
+       "catalogs_visited": 250,
+       "geih_matches": 232,
+       "errors": []
+     }
+   }
+```
+
+5. **The file `_scraped_catalog.json` is committed** to the repo. This makes the catalog reproducible without re-scraping.
+
+6. **Discovery strategy for catalog IDs**:
+   - Anchor: catalog 819 = 2024-06
+   - Forward: increment IDs until we hit 5 consecutive non-GEIH catalogs (heuristic stop)
+   - Backward: decrement IDs until we cover Aug 2006 (catalog ID estimated lower 100s based on chronology)
+   - Cache discovered catalogs in `_scraped_catalog.json` for incremental updates
+
+7. **Network resilience**:
+   - Timeout: 10s per request
+   - Retries: 3 with exponential backoff
+   - User-Agent: `pulso-catalog-scraper/0.3.1 (https://github.com/Stebandido77/pulso)`
+   - Rate limiting: 1 request per 2 seconds (be nice to DANE)
+
+8. **Gap handling**:
+   - Months explicitly missing from DANE → recorded in `gaps[]` with reason
+   - Months where scraping failed (network error) → recorded in `scrape_log.errors[]` for retry
+   - Months with non-standard structure → flagged in `anomalies[]` for human review
+
+## Consequences
+
+### Positive
+
+- Reproducibility: anyone can re-run the scraper to verify catalog state
+- Maintainability: new months are added by re-running the script
+- Transparency: scraping logic is explicit and auditable
+- Phase 3.2 enabler: with `_scraped_catalog.json` we can deterministically generate `sources.json`
+
+### Negative
+
+- Brittleness: if DANE redesigns their website, the scraper breaks. Mitigation: committed `_scraped_catalog.json` survives a redesign.
+- Catalog ID heuristic: assuming sequential IDs can fail if DANE renumbers. Documented assumption.
+
+### Mitigations
+
+- Scraper logs all decisions and outputs detailed scrape_log
+- A separate verification step in Phase 3.2 will re-fetch a sample to detect drift
+- `docs/CATALOG_NOTES.md` records all assumptions and known anomalies
+
+## Alternatives considered
+
+### Manual catalog curation
+
+Reject. 230 months × ~10 fields each = 2,300 manual entries. Error-prone, not maintainable.
+
+### DANE provides a machine-readable API
+
+DANE does not currently publish an API for catalog enumeration. If they add one, we should switch.
+
+### Scraping at runtime (no committed catalog)
+
+Reject. This would make pulso depend on DANE being online and stable for every user.
+
+## References
+
+- DANE catalog landing: https://microdatos.dane.gov.co/index.php/catalog
+- ADR 0001: Multi-agent build model (Curator owns data files)
+- ADR 0003: Schema 1.1.0
+- Phase 2 sources.json structure (validated for 1 entry)
+
+## Decision date
+
+2026-05-01
+
+## Authors
+
+Architect (Claude in chat) + Esteban Labastidas

--- a/pulso/data/_scraped_catalog.json
+++ b/pulso/data/_scraped_catalog.json
@@ -1,0 +1,3465 @@
+{
+  "scraped_at": "2026-05-01T06:06:52.660123+00:00",
+  "scraped_by": "scripts/scrape_dane_catalog.py",
+  "schema_version": "0.1.0",
+  "entries": [
+    {
+      "year": 2007,
+      "month": 1,
+      "catalog_id": 317,
+      "file_id": 13491,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/13491",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 6857687,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Enero.csv",
+      "anomalies": [
+        "Multiple formats available: Enero, Enero.dta"
+      ]
+    },
+    {
+      "year": 2007,
+      "month": 2,
+      "catalog_id": 317,
+      "file_id": 13493,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/13493",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7570718,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Febrero.csv",
+      "anomalies": [
+        "Multiple formats available: Febrero, Febrero.dta"
+      ]
+    },
+    {
+      "year": 2007,
+      "month": 3,
+      "catalog_id": 317,
+      "file_id": 13495,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/13495",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7654604,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Marzo.csv",
+      "anomalies": [
+        "Multiple formats available: Marzo, Marzo.dta"
+      ]
+    },
+    {
+      "year": 2007,
+      "month": 4,
+      "catalog_id": 317,
+      "file_id": 13497,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/13497",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7717519,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Abril.csv",
+      "anomalies": [
+        "Multiple formats available: Abril, Abril.dta, Abril.txt"
+      ]
+    },
+    {
+      "year": 2007,
+      "month": 5,
+      "catalog_id": 317,
+      "file_id": 13499,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/13499",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7560232,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Mayo.csv",
+      "anomalies": [
+        "Multiple formats available: Mayo, Mayo.dta, Mayo.txt"
+      ]
+    },
+    {
+      "year": 2007,
+      "month": 6,
+      "catalog_id": 317,
+      "file_id": 13501,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/13501",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7465861,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Junio.csv",
+      "anomalies": [
+        "Multiple formats available: Junio, Junio.dta, Junio.txt"
+      ]
+    },
+    {
+      "year": 2007,
+      "month": 7,
+      "catalog_id": 317,
+      "file_id": 13503,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/13503",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7518289,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Julio.csv",
+      "anomalies": [
+        "Multiple formats available: Julio, Julio.dta, Julio.txt"
+      ]
+    },
+    {
+      "year": 2007,
+      "month": 8,
+      "catalog_id": 317,
+      "file_id": 13505,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/13505",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7623147,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Agosto.csv",
+      "anomalies": [
+        "Multiple formats available: Agosto, Agosto.dta, Agosto.txt"
+      ]
+    },
+    {
+      "year": 2007,
+      "month": 9,
+      "catalog_id": 317,
+      "file_id": 10924,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/10924",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7497318,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Septiembre.csv",
+      "anomalies": [
+        "Multiple formats available: Septiembre.spss, Septiembre.dta"
+      ]
+    },
+    {
+      "year": 2007,
+      "month": 10,
+      "catalog_id": 317,
+      "file_id": 10928,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/10928",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7413432,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Octubre.csv",
+      "anomalies": [
+        "Multiple formats available: Octubre.spss, Octubre.dta"
+      ]
+    },
+    {
+      "year": 2007,
+      "month": 11,
+      "catalog_id": 317,
+      "file_id": 10930,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/10930",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7014973,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Noviembre.csv",
+      "anomalies": [
+        "Multiple formats available: Noviembre.spss, Noviembre.dta"
+      ]
+    },
+    {
+      "year": 2007,
+      "month": 12,
+      "catalog_id": 317,
+      "file_id": 10934,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/10934",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 6406799,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Diciembre.csv",
+      "anomalies": [
+        "Multiple formats available: Diciembre.spss, Diciembre.dta"
+      ]
+    },
+    {
+      "year": 2008,
+      "month": 1,
+      "catalog_id": 206,
+      "file_id": 3268,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/3268",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 14921236,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Enero",
+      "anomalies": [
+        "Multiple formats available: Enero txt., Enero_csv"
+      ]
+    },
+    {
+      "year": 2008,
+      "month": 2,
+      "catalog_id": 206,
+      "file_id": 3269,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/3269",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 15382609,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Febrero",
+      "anomalies": [
+        "Multiple formats available: Febrero txt., Febrero_csv"
+      ]
+    },
+    {
+      "year": 2008,
+      "month": 3,
+      "catalog_id": 206,
+      "file_id": 3270,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/3270",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 15015608,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Marzo",
+      "anomalies": [
+        "Multiple formats available: Marzo txt., Marzo_csv"
+      ]
+    },
+    {
+      "year": 2008,
+      "month": 4,
+      "catalog_id": 206,
+      "file_id": 12794,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12794",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 7361003,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Abril.csv",
+      "anomalies": [
+        "Multiple formats available: Abril, Abril txt."
+      ]
+    },
+    {
+      "year": 2008,
+      "month": 5,
+      "catalog_id": 206,
+      "file_id": 12795,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12795",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 7172259,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Mayo.csv",
+      "anomalies": [
+        "Multiple formats available: Mayo, Mayo txt."
+      ]
+    },
+    {
+      "year": 2008,
+      "month": 6,
+      "catalog_id": 206,
+      "file_id": 12796,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12796",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 6784286,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Junio.csv",
+      "anomalies": [
+        "Multiple formats available: Junio, Junio txt."
+      ]
+    },
+    {
+      "year": 2008,
+      "month": 7,
+      "catalog_id": 206,
+      "file_id": 12798,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12798",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 6815744,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Julio.csv",
+      "anomalies": [
+        "Multiple formats available: Julio, Julio txt."
+      ]
+    },
+    {
+      "year": 2008,
+      "month": 8,
+      "catalog_id": 206,
+      "file_id": 12799,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12799",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 6878658,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Agosto.csv",
+      "anomalies": [
+        "Multiple formats available: Agosto, Agosto txt."
+      ]
+    },
+    {
+      "year": 2008,
+      "month": 9,
+      "catalog_id": 206,
+      "file_id": 12800,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12800",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 6700400,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Septiembre.csv",
+      "anomalies": [
+        "Multiple formats available: Septiembre, Septiembre txt."
+      ]
+    },
+    {
+      "year": 2008,
+      "month": 10,
+      "catalog_id": 206,
+      "file_id": 12801,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12801",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 6910115,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Octubre.csv",
+      "anomalies": [
+        "Multiple formats available: Octubre, Octubre txt."
+      ]
+    },
+    {
+      "year": 2008,
+      "month": 11,
+      "catalog_id": 206,
+      "file_id": 12802,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12802",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 6815744,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Noviembre.csv",
+      "anomalies": [
+        "Multiple formats available: Noviembre, Noviembre txt."
+      ]
+    },
+    {
+      "year": 2008,
+      "month": 12,
+      "catalog_id": 206,
+      "file_id": 12803,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12803",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 6438256,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Diciembre.csv",
+      "anomalies": [
+        "Multiple formats available: Diciembre, Diciembre txt."
+      ]
+    },
+    {
+      "year": 2009,
+      "month": 1,
+      "catalog_id": 207,
+      "file_id": 12995,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/12995",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6207569,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Enero.csv",
+      "anomalies": [
+        "Multiple formats available: Enero, Enero.txt"
+      ]
+    },
+    {
+      "year": 2009,
+      "month": 2,
+      "catalog_id": 207,
+      "file_id": 12996,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/12996",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6469713,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Febrero.csv",
+      "anomalies": [
+        "Multiple formats available: Febrero, Febrero.txt"
+      ]
+    },
+    {
+      "year": 2009,
+      "month": 3,
+      "catalog_id": 207,
+      "file_id": 12997,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/12997",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6427770,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Marzo.csv",
+      "anomalies": [
+        "Multiple formats available: Marzo, Marzo.txt"
+      ]
+    },
+    {
+      "year": 2009,
+      "month": 4,
+      "catalog_id": 207,
+      "file_id": 12998,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/12998",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6616514,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Abril.csv",
+      "anomalies": [
+        "Multiple formats available: Abril, Abril.txt"
+      ]
+    },
+    {
+      "year": 2009,
+      "month": 5,
+      "catalog_id": 207,
+      "file_id": 12999,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/12999",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6553600,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Mayo.csv",
+      "anomalies": [
+        "Multiple formats available: Mayo, Mayo.txt"
+      ]
+    },
+    {
+      "year": 2009,
+      "month": 6,
+      "catalog_id": 207,
+      "file_id": 13000,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/13000",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6448742,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Junio.csv",
+      "anomalies": [
+        "Multiple formats available: Junio, Junio.txt"
+      ]
+    },
+    {
+      "year": 2009,
+      "month": 7,
+      "catalog_id": 207,
+      "file_id": 13001,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/13001",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6763315,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Julio.csv",
+      "anomalies": [
+        "Multiple formats available: Julio, Julio.txt"
+      ]
+    },
+    {
+      "year": 2009,
+      "month": 8,
+      "catalog_id": 207,
+      "file_id": 13002,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/13002",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6784286,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Agosto.csv",
+      "anomalies": [
+        "Multiple formats available: Agosto, Agosto.txt"
+      ]
+    },
+    {
+      "year": 2009,
+      "month": 9,
+      "catalog_id": 207,
+      "file_id": 13003,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/13003",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6763315,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Septiembre.csv",
+      "anomalies": [
+        "Multiple formats available: Septiembre, Septiembre.txt"
+      ]
+    },
+    {
+      "year": 2009,
+      "month": 10,
+      "catalog_id": 207,
+      "file_id": 13004,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/13004",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6742343,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Octubre.csv",
+      "anomalies": [
+        "Multiple formats available: Octubre, Octubre.txt"
+      ]
+    },
+    {
+      "year": 2009,
+      "month": 11,
+      "catalog_id": 207,
+      "file_id": 13005,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/13005",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6700400,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Noviembre.csv",
+      "anomalies": [
+        "Multiple formats available: Noviembre, Noviembre.txt"
+      ]
+    },
+    {
+      "year": 2009,
+      "month": 12,
+      "catalog_id": 207,
+      "file_id": 13006,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/13006",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6448742,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Diciembre.csv",
+      "anomalies": [
+        "Multiple formats available: Diciembre, Diciembre.txt"
+      ]
+    },
+    {
+      "year": 2010,
+      "month": 1,
+      "catalog_id": 205,
+      "file_id": 12974,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12974",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 6721372,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Enero.csv",
+      "anomalies": [
+        "Multiple formats available: Enero, Enero txt."
+      ]
+    },
+    {
+      "year": 2010,
+      "month": 2,
+      "catalog_id": 205,
+      "file_id": 12975,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12975",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 6920601,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Febrero.csv",
+      "anomalies": [
+        "Multiple formats available: Febrero, Febrero txt."
+      ]
+    },
+    {
+      "year": 2010,
+      "month": 3,
+      "catalog_id": 205,
+      "file_id": 12976,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12976",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 6763315,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Marzo.csv",
+      "anomalies": [
+        "Multiple formats available: Marzo, Marzo txt."
+      ]
+    },
+    {
+      "year": 2010,
+      "month": 4,
+      "catalog_id": 205,
+      "file_id": 12977,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12977",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 7161774,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Abril.csv",
+      "anomalies": [
+        "Multiple formats available: Abril, Abril txt."
+      ]
+    },
+    {
+      "year": 2010,
+      "month": 5,
+      "catalog_id": 205,
+      "file_id": 12978,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12978",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 6962544,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Mayo.csv",
+      "anomalies": [
+        "Multiple formats available: Mayo, Mayo txt."
+      ]
+    },
+    {
+      "year": 2010,
+      "month": 6,
+      "catalog_id": 205,
+      "file_id": 12979,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12979",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 6857687,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Junio.csv",
+      "anomalies": [
+        "Multiple formats available: Junio, Junio txt."
+      ]
+    },
+    {
+      "year": 2010,
+      "month": 7,
+      "catalog_id": 205,
+      "file_id": 12980,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12980",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 6994001,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Julio.csv",
+      "anomalies": [
+        "Multiple formats available: Julio, Julio txt."
+      ]
+    },
+    {
+      "year": 2010,
+      "month": 8,
+      "catalog_id": 205,
+      "file_id": 12981,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12981",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 7172259,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Agosto.csv.",
+      "anomalies": [
+        "Multiple formats available: Agosto, Agosto txt."
+      ]
+    },
+    {
+      "year": 2010,
+      "month": 9,
+      "catalog_id": 205,
+      "file_id": 12982,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12982",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 7140802,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Septiembre.csv.",
+      "anomalies": [
+        "Multiple formats available: Septiembre, Septiembre txt."
+      ]
+    },
+    {
+      "year": 2010,
+      "month": 10,
+      "catalog_id": 205,
+      "file_id": 12983,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12983",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 7098859,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Octubre.csv.",
+      "anomalies": [
+        "Multiple formats available: Octubre, Octubre txt."
+      ]
+    },
+    {
+      "year": 2010,
+      "month": 11,
+      "catalog_id": 205,
+      "file_id": 12984,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12984",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 7109345,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Noviembre.csv.",
+      "anomalies": [
+        "Multiple formats available: Noviembre, Noviembre txt."
+      ]
+    },
+    {
+      "year": 2010,
+      "month": 12,
+      "catalog_id": 205,
+      "file_id": 12985,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12985",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 6805258,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Diciembre.csv.",
+      "anomalies": [
+        "Multiple formats available: Diciembre, Diciembre txt."
+      ]
+    },
+    {
+      "year": 2011,
+      "month": 1,
+      "catalog_id": 182,
+      "file_id": 12719,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12719",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 6847201,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Enero.csv",
+      "anomalies": [
+        "Multiple formats available: Enero.sav, Enero.txt"
+      ]
+    },
+    {
+      "year": 2011,
+      "month": 2,
+      "catalog_id": 182,
+      "file_id": 12720,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12720",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7528775,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Febrero.csv",
+      "anomalies": [
+        "Multiple formats available: Febrero.sav., Febrero.txt"
+      ]
+    },
+    {
+      "year": 2011,
+      "month": 3,
+      "catalog_id": 182,
+      "file_id": 12721,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12721",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7277117,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Marzo.csv",
+      "anomalies": [
+        "Multiple formats available: Marzo.sav, Marzo.txt"
+      ]
+    },
+    {
+      "year": 2011,
+      "month": 4,
+      "catalog_id": 182,
+      "file_id": 12722,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12722",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 6910115,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Abril.csv.",
+      "anomalies": [
+        "Multiple formats available: Abril.sav, Abril.txt"
+      ]
+    },
+    {
+      "year": 2011,
+      "month": 5,
+      "catalog_id": 182,
+      "file_id": 12723,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12723",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7245660,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Mayo.csv",
+      "anomalies": [
+        "Multiple formats available: Mayo.sav, Mayo.txt"
+      ]
+    },
+    {
+      "year": 2011,
+      "month": 6,
+      "catalog_id": 182,
+      "file_id": 12724,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12724",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7235174,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Junio.csv",
+      "anomalies": [
+        "Multiple formats available: Junio.sav, Junio.txt"
+      ]
+    },
+    {
+      "year": 2011,
+      "month": 7,
+      "catalog_id": 182,
+      "file_id": 12725,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12725",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7266631,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Julio.csv",
+      "anomalies": [
+        "Multiple formats available: Julio.sav, Julio.txt"
+      ]
+    },
+    {
+      "year": 2011,
+      "month": 8,
+      "catalog_id": 182,
+      "file_id": 12726,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12726",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7214202,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Agosto.csv",
+      "anomalies": [
+        "Multiple formats available: Agosto.sav, Agosto.txt"
+      ]
+    },
+    {
+      "year": 2011,
+      "month": 9,
+      "catalog_id": 182,
+      "file_id": 12727,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12727",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7182745,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Septiembre.csv",
+      "anomalies": [
+        "Multiple formats available: Septiembre.sav, Septiembre.txt"
+      ]
+    },
+    {
+      "year": 2011,
+      "month": 10,
+      "catalog_id": 182,
+      "file_id": 12728,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12728",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7140802,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Octubre.csv",
+      "anomalies": [
+        "Multiple formats available: Octubre.sav., Octubre.txt"
+      ]
+    },
+    {
+      "year": 2011,
+      "month": 11,
+      "catalog_id": 182,
+      "file_id": 12729,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12729",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7214202,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Noviembre.csv",
+      "anomalies": [
+        "Multiple formats available: Noviembre.sav, Noviembre.txt"
+      ]
+    },
+    {
+      "year": 2011,
+      "month": 12,
+      "catalog_id": 182,
+      "file_id": 12730,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12730",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 6962544,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Diciembre.csv",
+      "anomalies": [
+        "Multiple formats available: Diciembre.sav, Diciembre.txt"
+      ]
+    },
+    {
+      "year": 2012,
+      "month": 1,
+      "catalog_id": 77,
+      "file_id": 13013,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13013",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 6847201,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Enero.csv",
+      "anomalies": [
+        "Multiple formats available: Enero, Enero.txt"
+      ]
+    },
+    {
+      "year": 2012,
+      "month": 2,
+      "catalog_id": 77,
+      "file_id": 13014,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13014",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7193231,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Febrero.csv",
+      "anomalies": [
+        "Multiple formats available: Febrero, Febrero.txt"
+      ]
+    },
+    {
+      "year": 2012,
+      "month": 3,
+      "catalog_id": 77,
+      "file_id": 13015,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13015",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7130316,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Marzo.csv",
+      "anomalies": [
+        "Multiple formats available: Marzo, Marzo.txt"
+      ]
+    },
+    {
+      "year": 2012,
+      "month": 4,
+      "catalog_id": 77,
+      "file_id": 13016,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13016",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7214202,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Abril.csv",
+      "anomalies": [
+        "Multiple formats available: Abril, Abril.txt"
+      ]
+    },
+    {
+      "year": 2012,
+      "month": 5,
+      "catalog_id": 77,
+      "file_id": 13017,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13017",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7476346,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Mayo.csv",
+      "anomalies": [
+        "Multiple formats available: Mayo, Mayo.txt"
+      ]
+    },
+    {
+      "year": 2012,
+      "month": 6,
+      "catalog_id": 77,
+      "file_id": 13018,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13018",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7109345,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Junio.csv",
+      "anomalies": [
+        "Multiple formats available: Junio, Junio.txt"
+      ]
+    },
+    {
+      "year": 2012,
+      "month": 7,
+      "catalog_id": 77,
+      "file_id": 13019,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13019",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7067402,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Julio.csv",
+      "anomalies": [
+        "Multiple formats available: Julio, Julio.txt"
+      ]
+    },
+    {
+      "year": 2012,
+      "month": 8,
+      "catalog_id": 77,
+      "file_id": 13020,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13020",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7203717,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Agosto.csv",
+      "anomalies": [
+        "Multiple formats available: Agosto, Agosto.txt"
+      ]
+    },
+    {
+      "year": 2012,
+      "month": 9,
+      "catalog_id": 77,
+      "file_id": 13021,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13021",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7109345,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Septiembre.csv",
+      "anomalies": [
+        "Multiple formats available: Septiembre, Septiembre.txt"
+      ]
+    },
+    {
+      "year": 2012,
+      "month": 10,
+      "catalog_id": 77,
+      "file_id": 13022,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13022",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7172259,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Octubre.csv",
+      "anomalies": [
+        "Multiple formats available: Octubre, Octubre.txt"
+      ]
+    },
+    {
+      "year": 2012,
+      "month": 11,
+      "catalog_id": 77,
+      "file_id": 13023,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13023",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7235174,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Noviembre.csv.",
+      "anomalies": [
+        "Multiple formats available: Noviembre, Noviembre.txt"
+      ]
+    },
+    {
+      "year": 2012,
+      "month": 12,
+      "catalog_id": 77,
+      "file_id": 13024,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13024",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 6637486,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Diciembre.csv",
+      "anomalies": [
+        "Multiple formats available: Diciembre, Diciembre.txt"
+      ]
+    },
+    {
+      "year": 2013,
+      "month": 1,
+      "catalog_id": 68,
+      "file_id": 13027,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13027",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 7004487,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Enero.csv",
+      "anomalies": [
+        "Multiple formats available: Enero, Enero.txt"
+      ]
+    },
+    {
+      "year": 2013,
+      "month": 2,
+      "catalog_id": 68,
+      "file_id": 13028,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13028",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 7004487,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Febrero.csv",
+      "anomalies": [
+        "Multiple formats available: Febrero, Febrero.txt"
+      ]
+    },
+    {
+      "year": 2013,
+      "month": 3,
+      "catalog_id": 68,
+      "file_id": 13029,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13029",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6889144,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Marzo.csv",
+      "anomalies": [
+        "Multiple formats available: Marzo, Marzo.txt"
+      ]
+    },
+    {
+      "year": 2013,
+      "month": 4,
+      "catalog_id": 68,
+      "file_id": 13030,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13030",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6973030,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Abril.csv",
+      "anomalies": [
+        "Multiple formats available: Abril, Abril.txt"
+      ]
+    },
+    {
+      "year": 2013,
+      "month": 5,
+      "catalog_id": 68,
+      "file_id": 13031,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13031",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 7109345,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Mayo.csv",
+      "anomalies": [
+        "Multiple formats available: Mayo, Mayo.txt"
+      ]
+    },
+    {
+      "year": 2013,
+      "month": 6,
+      "catalog_id": 68,
+      "file_id": 13032,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13032",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6962544,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Junio.csv",
+      "anomalies": [
+        "Multiple formats available: Junio, Junio.txt"
+      ]
+    },
+    {
+      "year": 2013,
+      "month": 7,
+      "catalog_id": 68,
+      "file_id": 13033,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13033",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6836715,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Julio.csv",
+      "anomalies": [
+        "Multiple formats available: Julio, Julio.txt"
+      ]
+    },
+    {
+      "year": 2013,
+      "month": 8,
+      "catalog_id": 68,
+      "file_id": 13034,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13034",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6899630,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Agosto.csv",
+      "anomalies": [
+        "Multiple formats available: Agosto, Agosto.txt"
+      ]
+    },
+    {
+      "year": 2013,
+      "month": 9,
+      "catalog_id": 68,
+      "file_id": 13035,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13035",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6794772,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Septiembre.csv",
+      "anomalies": [
+        "Multiple formats available: Septiembre, Septiembre.txt."
+      ]
+    },
+    {
+      "year": 2013,
+      "month": 10,
+      "catalog_id": 68,
+      "file_id": 13036,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13036",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6952058,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Octubre.csv",
+      "anomalies": [
+        "Multiple formats available: Octubre, Octubre.txt"
+      ]
+    },
+    {
+      "year": 2013,
+      "month": 11,
+      "catalog_id": 68,
+      "file_id": 13037,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13037",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6836715,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Noviembre.csv",
+      "anomalies": [
+        "Multiple formats available: Noviembre, Noviembre.txt"
+      ]
+    },
+    {
+      "year": 2013,
+      "month": 12,
+      "catalog_id": 68,
+      "file_id": 13038,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13038",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6427770,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Diciembre.csv",
+      "anomalies": [
+        "Multiple formats available: Diciembre, Diciembre.txt"
+      ]
+    },
+    {
+      "year": 2014,
+      "month": 1,
+      "catalog_id": 328,
+      "file_id": 13043,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13043",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6752829,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Enero.csv",
+      "anomalies": [
+        "Multiple formats available: Enero, Enero.txt"
+      ]
+    },
+    {
+      "year": 2014,
+      "month": 2,
+      "catalog_id": 328,
+      "file_id": 13044,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13044",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6826229,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Febrero.csv",
+      "anomalies": [
+        "Multiple formats available: Febrero, Febrero.txt"
+      ]
+    },
+    {
+      "year": 2014,
+      "month": 3,
+      "catalog_id": 328,
+      "file_id": 13045,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13045",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6679429,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Marzo.csv",
+      "anomalies": [
+        "Multiple formats available: Marzo, Marzo.txt"
+      ]
+    },
+    {
+      "year": 2014,
+      "month": 4,
+      "catalog_id": 328,
+      "file_id": 13046,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13046",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6658457,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Abril.csv",
+      "anomalies": [
+        "Multiple formats available: Abril, Abril.txt"
+      ]
+    },
+    {
+      "year": 2014,
+      "month": 5,
+      "catalog_id": 328,
+      "file_id": 13047,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13047",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6931087,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Mayo.csv",
+      "anomalies": [
+        "Multiple formats available: Mayo, Mayo.txt"
+      ]
+    },
+    {
+      "year": 2014,
+      "month": 6,
+      "catalog_id": 328,
+      "file_id": 13048,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13048",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6532628,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Junio.csv",
+      "anomalies": [
+        "Multiple formats available: Junio, Junio.txt"
+      ]
+    },
+    {
+      "year": 2014,
+      "month": 7,
+      "catalog_id": 328,
+      "file_id": 13049,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13049",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6710886,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Julio.csv",
+      "anomalies": [
+        "Multiple formats available: Julio, Julio.txt"
+      ]
+    },
+    {
+      "year": 2014,
+      "month": 8,
+      "catalog_id": 328,
+      "file_id": 13050,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13050",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6815744,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Agosto.csv",
+      "anomalies": [
+        "Multiple formats available: Agosto, Agosto.txt"
+      ]
+    },
+    {
+      "year": 2014,
+      "month": 9,
+      "catalog_id": 328,
+      "file_id": 13051,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13051",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6658457,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Septiembre.csv",
+      "anomalies": [
+        "Multiple formats available: Septiembre, Septiembre.txt"
+      ]
+    },
+    {
+      "year": 2014,
+      "month": 10,
+      "catalog_id": 328,
+      "file_id": 13052,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13052",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 7014973,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Octubre.csv",
+      "anomalies": [
+        "Multiple formats available: Octubre, Octubre.txt"
+      ]
+    },
+    {
+      "year": 2014,
+      "month": 11,
+      "catalog_id": 328,
+      "file_id": 13053,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13053",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6700400,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Noviembre.csv",
+      "anomalies": [
+        "Multiple formats available: Noviembre, Noviembre.txt"
+      ]
+    },
+    {
+      "year": 2014,
+      "month": 12,
+      "catalog_id": 328,
+      "file_id": 13054,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13054",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6417285,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Diciembre.csv",
+      "anomalies": [
+        "Multiple formats available: Diciembre, Diciembre.txt"
+      ]
+    },
+    {
+      "year": 2015,
+      "month": 1,
+      "catalog_id": 356,
+      "file_id": 13056,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13056",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6585057,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Enero.csv",
+      "anomalies": [
+        "Multiple formats available: Enero, Enero.txt"
+      ]
+    },
+    {
+      "year": 2015,
+      "month": 2,
+      "catalog_id": 356,
+      "file_id": 13057,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13057",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6710886,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Febrero.csv",
+      "anomalies": [
+        "Multiple formats available: Febrero, Febrero.txt"
+      ]
+    },
+    {
+      "year": 2015,
+      "month": 3,
+      "catalog_id": 356,
+      "file_id": 13058,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13058",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6689914,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Marzo.csv",
+      "anomalies": [
+        "Multiple formats available: Marzo, Marzo.txt"
+      ]
+    },
+    {
+      "year": 2015,
+      "month": 4,
+      "catalog_id": 356,
+      "file_id": 13059,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13059",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6910115,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Abril.csv",
+      "anomalies": [
+        "Multiple formats available: Abril, Abril.txt"
+      ]
+    },
+    {
+      "year": 2015,
+      "month": 5,
+      "catalog_id": 356,
+      "file_id": 13060,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13060",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6763315,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Mayo.csv",
+      "anomalies": [
+        "Multiple formats available: Mayo, Mayo.txt"
+      ]
+    },
+    {
+      "year": 2015,
+      "month": 6,
+      "catalog_id": 356,
+      "file_id": 13061,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13061",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6668943,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Junio.csv",
+      "anomalies": [
+        "Multiple formats available: Junio, Junio.txt"
+      ]
+    },
+    {
+      "year": 2015,
+      "month": 7,
+      "catalog_id": 356,
+      "file_id": 13062,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13062",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6899630,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Julio.csv",
+      "anomalies": [
+        "Multiple formats available: Julio, Julio.txt"
+      ]
+    },
+    {
+      "year": 2015,
+      "month": 8,
+      "catalog_id": 356,
+      "file_id": 13063,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13063",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6910115,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Agosto.csv",
+      "anomalies": [
+        "Multiple formats available: Agosto, Agosto txt"
+      ]
+    },
+    {
+      "year": 2015,
+      "month": 9,
+      "catalog_id": 356,
+      "file_id": 13064,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13064",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6857687,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Septiembre.csv",
+      "anomalies": [
+        "Multiple formats available: Septiembre, Septiembre.txt"
+      ]
+    },
+    {
+      "year": 2015,
+      "month": 10,
+      "catalog_id": 356,
+      "file_id": 13065,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13065",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6962544,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Octubre.csv",
+      "anomalies": [
+        "Multiple formats available: Octubre, Octubre.txt."
+      ]
+    },
+    {
+      "year": 2015,
+      "month": 11,
+      "catalog_id": 356,
+      "file_id": 13066,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13066",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6847201,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Noviembre.csv",
+      "anomalies": [
+        "Multiple formats available: Noviembre, Noviembre.txt"
+      ]
+    },
+    {
+      "year": 2015,
+      "month": 12,
+      "catalog_id": 356,
+      "file_id": 13067,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13067",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6616514,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Diciembre.csv",
+      "anomalies": [
+        "Multiple formats available: Diciembre, Diciembre.txt"
+      ]
+    },
+    {
+      "year": 2016,
+      "month": 1,
+      "catalog_id": 427,
+      "file_id": 13101,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13101",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 6616514,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Enero.csv",
+      "anomalies": [
+        "Multiple formats available: Enero, Enero.txt"
+      ]
+    },
+    {
+      "year": 2016,
+      "month": 2,
+      "catalog_id": 427,
+      "file_id": 13102,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13102",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 6647971,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Febrero.csv",
+      "anomalies": [
+        "Multiple formats available: Febrero, Febrero.txt"
+      ]
+    },
+    {
+      "year": 2016,
+      "month": 3,
+      "catalog_id": 427,
+      "file_id": 13103,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13103",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 7130316,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Marzo.csv",
+      "anomalies": [
+        "Multiple formats available: Marzo, Marzo.txt"
+      ]
+    },
+    {
+      "year": 2016,
+      "month": 4,
+      "catalog_id": 427,
+      "file_id": 13104,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13104",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 6773800,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Abril.csv",
+      "anomalies": [
+        "Multiple formats available: Abril, Abril.txt"
+      ]
+    },
+    {
+      "year": 2016,
+      "month": 5,
+      "catalog_id": 427,
+      "file_id": 13105,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13105",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 7014973,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Mayo.csv.",
+      "anomalies": [
+        "Multiple formats available: Mayo, Mayo.txt"
+      ]
+    },
+    {
+      "year": 2016,
+      "month": 6,
+      "catalog_id": 427,
+      "file_id": 13106,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13106",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 7046430,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Junio.csv",
+      "anomalies": [
+        "Multiple formats available: Junio, Junio.txt"
+      ]
+    },
+    {
+      "year": 2016,
+      "month": 7,
+      "catalog_id": 427,
+      "file_id": 13107,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13107",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 7014973,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Julio.csv",
+      "anomalies": [
+        "Multiple formats available: Julio, Julio.txt"
+      ]
+    },
+    {
+      "year": 2016,
+      "month": 8,
+      "catalog_id": 427,
+      "file_id": 13108,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13108",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 6962544,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Agosto.csv",
+      "anomalies": [
+        "Multiple formats available: Agosto, Agosto.txt"
+      ]
+    },
+    {
+      "year": 2016,
+      "month": 9,
+      "catalog_id": 427,
+      "file_id": 13109,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13109",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 6721372,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Septiembre.csv",
+      "anomalies": [
+        "Multiple formats available: Septiembre, Septiembre.txt"
+      ]
+    },
+    {
+      "year": 2016,
+      "month": 10,
+      "catalog_id": 427,
+      "file_id": 13110,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13110",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 6606028,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Octubre.csv",
+      "anomalies": [
+        "Multiple formats available: Octubre, Octubre.txt"
+      ]
+    },
+    {
+      "year": 2016,
+      "month": 11,
+      "catalog_id": 427,
+      "file_id": 13111,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13111",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 6574571,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Noviembre.csv",
+      "anomalies": [
+        "Multiple formats available: Noviembre, Noviembre.txt"
+      ]
+    },
+    {
+      "year": 2016,
+      "month": 12,
+      "catalog_id": 427,
+      "file_id": 13112,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13112",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 6364856,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Diciembre.csv",
+      "anomalies": [
+        "Multiple formats available: Diciembre, Diciembre.txt"
+      ]
+    },
+    {
+      "year": 2017,
+      "month": 1,
+      "catalog_id": 458,
+      "file_id": 13294,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/13294",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 6417285,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Enero.csv",
+      "anomalies": [
+        "Multiple formats available: Enero, Enero.txt"
+      ]
+    },
+    {
+      "year": 2017,
+      "month": 2,
+      "catalog_id": 458,
+      "file_id": 13295,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/13295",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 6553600,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Febrero.csv.",
+      "anomalies": [
+        "Multiple formats available: Febrero, Febrero.txt"
+      ]
+    },
+    {
+      "year": 2017,
+      "month": 3,
+      "catalog_id": 458,
+      "file_id": 13296,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/13296",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 6490685,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Marzo.csv.",
+      "anomalies": [
+        "Multiple formats available: Marzo, Marzo.txt"
+      ]
+    },
+    {
+      "year": 2017,
+      "month": 4,
+      "catalog_id": 458,
+      "file_id": 13297,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/13297",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 6469713,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Abril.csv",
+      "anomalies": [
+        "Multiple formats available: Abril, Abril.txt"
+      ]
+    },
+    {
+      "year": 2017,
+      "month": 5,
+      "catalog_id": 458,
+      "file_id": 13298,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/13298",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 6679429,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Mayo.csv",
+      "anomalies": [
+        "Multiple formats available: Mayo, Mayo.txt"
+      ]
+    },
+    {
+      "year": 2017,
+      "month": 6,
+      "catalog_id": 458,
+      "file_id": 13299,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/13299",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 6553600,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Junio.csv",
+      "anomalies": [
+        "Multiple formats available: Junio, Junio.txt"
+      ]
+    },
+    {
+      "year": 2017,
+      "month": 7,
+      "catalog_id": 458,
+      "file_id": 13300,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/13300",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 6952058,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Julio.csv",
+      "anomalies": [
+        "Multiple formats available: Julio, Julio.txt"
+      ]
+    },
+    {
+      "year": 2017,
+      "month": 8,
+      "catalog_id": 458,
+      "file_id": 13301,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/13301",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 7035944,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Agosto.csv",
+      "anomalies": [
+        "Multiple formats available: Agosto, Agosto.txt"
+      ]
+    },
+    {
+      "year": 2017,
+      "month": 9,
+      "catalog_id": 458,
+      "file_id": 9035,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/9035",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 9133096,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Septiembre.csv",
+      "anomalies": [
+        "Multiple formats available: Septiembre.dta, Septiembre.txt"
+      ]
+    },
+    {
+      "year": 2017,
+      "month": 10,
+      "catalog_id": 458,
+      "file_id": 9038,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/9038",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 9133096,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Octubre.csv",
+      "anomalies": [
+        "Multiple formats available: Octubre.dta., Octubre.txt"
+      ]
+    },
+    {
+      "year": 2017,
+      "month": 11,
+      "catalog_id": 458,
+      "file_id": 9342,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/9342",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 9017753,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Noviembre.csv",
+      "anomalies": [
+        "Multiple formats available: Noviembre.dta, Noviembre.txt"
+      ]
+    },
+    {
+      "year": 2017,
+      "month": 12,
+      "catalog_id": 458,
+      "file_id": 9282,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/9282",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 8535408,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Diciembre.csv",
+      "anomalies": [
+        "Multiple formats available: Diciembre.dta, Diciembre.txt"
+      ]
+    },
+    {
+      "year": 2018,
+      "month": 1,
+      "catalog_id": 547,
+      "file_id": 12198,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/12198",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6606028,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Enero.csv",
+      "anomalies": [
+        "Multiple formats available: Enero.spss, Enero.dta"
+      ]
+    },
+    {
+      "year": 2018,
+      "month": 2,
+      "catalog_id": 547,
+      "file_id": 12201,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/12201",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6794772,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Febrero.csv",
+      "anomalies": [
+        "Multiple formats available: Febrero.spss, Febrero.dta"
+      ]
+    },
+    {
+      "year": 2018,
+      "month": 3,
+      "catalog_id": 547,
+      "file_id": 12204,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/12204",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6826229,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Marzo.csv",
+      "anomalies": [
+        "Multiple formats available: Marzo.spss, Marzo.dta"
+      ]
+    },
+    {
+      "year": 2018,
+      "month": 4,
+      "catalog_id": 547,
+      "file_id": 12207,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/12207",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6952058,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Abril.csv",
+      "anomalies": [
+        "Multiple formats available: abril.spss, Abril.dta"
+      ]
+    },
+    {
+      "year": 2018,
+      "month": 5,
+      "catalog_id": 547,
+      "file_id": 12210,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/12210",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 7119831,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Mayo.csv",
+      "anomalies": [
+        "Multiple formats available: Mayo.spss, Mayo.dta"
+      ]
+    },
+    {
+      "year": 2018,
+      "month": 6,
+      "catalog_id": 547,
+      "file_id": 9909,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/9909",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6647971,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Junio.csv",
+      "anomalies": [
+        "Multiple formats available: Junio.spss, Junio.dta"
+      ]
+    },
+    {
+      "year": 2018,
+      "month": 7,
+      "catalog_id": 547,
+      "file_id": 10017,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/10017",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6878658,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Julio.csv",
+      "anomalies": [
+        "Multiple formats available: Julio.spss, Julio.dta"
+      ]
+    },
+    {
+      "year": 2018,
+      "month": 8,
+      "catalog_id": 547,
+      "file_id": 10102,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/10102",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 7035944,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Agosto.csv",
+      "anomalies": [
+        "Multiple formats available: Agosto.spss, Agosto.dta"
+      ]
+    },
+    {
+      "year": 2018,
+      "month": 9,
+      "catalog_id": 547,
+      "file_id": 10115,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/10115",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6773800,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Septiembre.csv",
+      "anomalies": [
+        "Multiple formats available: Septiembre.spss, Septiembre.dta"
+      ]
+    },
+    {
+      "year": 2018,
+      "month": 10,
+      "catalog_id": 547,
+      "file_id": 10205,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/10205",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6742343,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Octubre.csv",
+      "anomalies": [
+        "Multiple formats available: Octubre.spss, Octubre.dta"
+      ]
+    },
+    {
+      "year": 2018,
+      "month": 11,
+      "catalog_id": 547,
+      "file_id": 10341,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/10341",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6794772,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Noviembre.csv",
+      "anomalies": [
+        "Multiple formats available: Noviembre.spss, Noviembre.dta"
+      ]
+    },
+    {
+      "year": 2018,
+      "month": 12,
+      "catalog_id": 547,
+      "file_id": 10443,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/10443",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6553600,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Diciembre.csv",
+      "anomalies": [
+        "Multiple formats available: Diciembre.spss, Diciembre.dta"
+      ]
+    },
+    {
+      "year": 2019,
+      "month": 1,
+      "catalog_id": 599,
+      "file_id": 10719,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/10719",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6784286,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Enero.csv",
+      "anomalies": [
+        "Multiple formats available: Enero.spss, Enero.dta"
+      ]
+    },
+    {
+      "year": 2019,
+      "month": 2,
+      "catalog_id": 599,
+      "file_id": 10964,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/10964",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6910115,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Febrero.csv",
+      "anomalies": [
+        "Multiple formats available: Febrero.spss, Febrero.dta"
+      ]
+    },
+    {
+      "year": 2019,
+      "month": 3,
+      "catalog_id": 599,
+      "file_id": 11117,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/11117",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6710886,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Marzo.csv",
+      "anomalies": [
+        "Multiple formats available: Marzo.spss, Marzo.dta"
+      ]
+    },
+    {
+      "year": 2019,
+      "month": 4,
+      "catalog_id": 599,
+      "file_id": 11184,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/11184",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6794772,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Abril.csv",
+      "anomalies": [
+        "Multiple formats available: Abril.spss, Abril.dta"
+      ]
+    },
+    {
+      "year": 2019,
+      "month": 5,
+      "catalog_id": 599,
+      "file_id": 11300,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/11300",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 7025459,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Mayo.csv",
+      "anomalies": [
+        "Multiple formats available: Mayo.spss, Mayo.dta"
+      ]
+    },
+    {
+      "year": 2019,
+      "month": 6,
+      "catalog_id": 599,
+      "file_id": 12068,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/12068",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6689914,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Junio.csv",
+      "anomalies": [
+        "Multiple formats available: Junio.spss, Junio.dta"
+      ]
+    },
+    {
+      "year": 2019,
+      "month": 7,
+      "catalog_id": 599,
+      "file_id": 12100,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/12100",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6815744,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Julio.csv",
+      "anomalies": [
+        "Multiple formats available: Julio.spss, Julio.dta"
+      ]
+    },
+    {
+      "year": 2019,
+      "month": 8,
+      "catalog_id": 599,
+      "file_id": 12221,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/12221",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6931087,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Agosto.csv",
+      "anomalies": [
+        "Multiple formats available: Agosto.spss, Agosto.dta"
+      ]
+    },
+    {
+      "year": 2019,
+      "month": 9,
+      "catalog_id": 599,
+      "file_id": 12275,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/12275",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6721372,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Septiembre.csv",
+      "anomalies": [
+        "Multiple formats available: Septiembre.spss, Septiembre.dta"
+      ]
+    },
+    {
+      "year": 2019,
+      "month": 10,
+      "catalog_id": 599,
+      "file_id": 12365,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/12365",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6805258,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Octubre.csv",
+      "anomalies": [
+        "Multiple formats available: Octubre.spss, Octubre.dta."
+      ]
+    },
+    {
+      "year": 2019,
+      "month": 11,
+      "catalog_id": 599,
+      "file_id": 12444,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/12444",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6668943,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Noviembre.csv",
+      "anomalies": [
+        "Multiple formats available: Noviembre.spss, Noviembre.dta"
+      ]
+    },
+    {
+      "year": 2019,
+      "month": 12,
+      "catalog_id": 599,
+      "file_id": 12516,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/12516",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6417285,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Diciembre.csv",
+      "anomalies": [
+        "Multiple formats available: Diciembre.spss, Diciembre.dta"
+      ]
+    },
+    {
+      "year": 2020,
+      "month": 1,
+      "catalog_id": 780,
+      "file_id": 22286,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22286",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 21799895,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Enero",
+      "anomalies": []
+    },
+    {
+      "year": 2020,
+      "month": 2,
+      "catalog_id": 780,
+      "file_id": 22287,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22287",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 21852323,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Febrero",
+      "anomalies": []
+    },
+    {
+      "year": 2020,
+      "month": 3,
+      "catalog_id": 780,
+      "file_id": 22288,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22288",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 10915676,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Marzo",
+      "anomalies": []
+    },
+    {
+      "year": 2020,
+      "month": 4,
+      "catalog_id": 780,
+      "file_id": 22289,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22289",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 8399093,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Abril",
+      "anomalies": []
+    },
+    {
+      "year": 2020,
+      "month": 5,
+      "catalog_id": 780,
+      "file_id": 22290,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22290",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 12289310,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Mayo",
+      "anomalies": []
+    },
+    {
+      "year": 2020,
+      "month": 6,
+      "catalog_id": 780,
+      "file_id": 22291,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22291",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 12278824,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Junio",
+      "anomalies": []
+    },
+    {
+      "year": 2020,
+      "month": 7,
+      "catalog_id": 780,
+      "file_id": 22292,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22292",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 12142510,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Julio",
+      "anomalies": []
+    },
+    {
+      "year": 2020,
+      "month": 8,
+      "catalog_id": 780,
+      "file_id": 22293,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22293",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 24043847,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Agosto",
+      "anomalies": []
+    },
+    {
+      "year": 2020,
+      "month": 9,
+      "catalog_id": 780,
+      "file_id": 22294,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22294",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 23708303,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Septiembre",
+      "anomalies": []
+    },
+    {
+      "year": 2020,
+      "month": 10,
+      "catalog_id": 780,
+      "file_id": 22295,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22295",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 24201134,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Octubre",
+      "anomalies": []
+    },
+    {
+      "year": 2020,
+      "month": 11,
+      "catalog_id": 780,
+      "file_id": 22296,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22296",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 23435673,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Noviembre",
+      "anomalies": []
+    },
+    {
+      "year": 2020,
+      "month": 12,
+      "catalog_id": 780,
+      "file_id": 22297,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22297",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 23330816,
+      "epoch_inferred": "geih_2006_2020",
+      "file_name": "Diciembre",
+      "anomalies": []
+    },
+    {
+      "year": 2021,
+      "month": 1,
+      "catalog_id": 701,
+      "file_id": 23451,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/23451",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 5463080,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Enero.csv",
+      "anomalies": [
+        "Multiple formats available: Enero.spss, Enero.dta"
+      ]
+    },
+    {
+      "year": 2021,
+      "month": 2,
+      "catalog_id": 701,
+      "file_id": 23454,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/23454",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 5494538,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Febrero.csv.",
+      "anomalies": [
+        "Multiple formats available: Febrero.spss, Febrero.dta."
+      ]
+    },
+    {
+      "year": 2021,
+      "month": 3,
+      "catalog_id": 701,
+      "file_id": 23457,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/23457",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 5400166,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Marzo.csv",
+      "anomalies": [
+        "Multiple formats available: Marzo.spss., Marzo.dta, GEIH_2021_Marco_2018 (II.Semestre)., GEIH_Marco_2018 (I.Semestre)."
+      ]
+    },
+    {
+      "year": 2021,
+      "month": 4,
+      "catalog_id": 701,
+      "file_id": 23460,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/23460",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 5546967,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Abril.csv.",
+      "anomalies": [
+        "Multiple formats available: Abril.spss, Abril.dta."
+      ]
+    },
+    {
+      "year": 2021,
+      "month": 5,
+      "catalog_id": 701,
+      "file_id": 20528,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20528",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 6627000,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Mayo.csv",
+      "anomalies": [
+        "Multiple formats available: Mayo.spss, Mayo.dta"
+      ]
+    },
+    {
+      "year": 2021,
+      "month": 6,
+      "catalog_id": 701,
+      "file_id": 20551,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20551",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 6176112,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Junio.csv",
+      "anomalies": [
+        "Multiple formats available: Junio.sav, Junio.dta"
+      ]
+    },
+    {
+      "year": 2021,
+      "month": 7,
+      "catalog_id": 701,
+      "file_id": 20630,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20630",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 6910115,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Julio.csv",
+      "anomalies": [
+        "Multiple formats available: Julio.spss, Julio.dta"
+      ]
+    },
+    {
+      "year": 2021,
+      "month": 8,
+      "catalog_id": 701,
+      "file_id": 20673,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20673",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 6574571,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Agosto.csv",
+      "anomalies": [
+        "Multiple formats available: Agosto.spss, Agosto.dta"
+      ]
+    },
+    {
+      "year": 2021,
+      "month": 9,
+      "catalog_id": 701,
+      "file_id": 20676,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20676",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 6490685,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Septiembre.csv",
+      "anomalies": [
+        "Multiple formats available: Septiembre.spss, Septiembre.dta"
+      ]
+    },
+    {
+      "year": 2021,
+      "month": 10,
+      "catalog_id": 701,
+      "file_id": 20707,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20707",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 6291456,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Octubre.csv",
+      "anomalies": [
+        "Multiple formats available: Octubre.spss, Octubre.dta"
+      ]
+    },
+    {
+      "year": 2021,
+      "month": 11,
+      "catalog_id": 701,
+      "file_id": 20833,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20833",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 5987368,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Noviembre.csv",
+      "anomalies": [
+        "Multiple formats available: Noviembre.spss, Noviembre.dta"
+      ]
+    },
+    {
+      "year": 2021,
+      "month": 12,
+      "catalog_id": 701,
+      "file_id": 20902,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20902",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 5924454,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Diciembre.csv",
+      "anomalies": [
+        "Multiple formats available: Diciembre.spss, Diciembre.dta"
+      ]
+    },
+    {
+      "year": 2022,
+      "month": 1,
+      "catalog_id": 771,
+      "file_id": 22688,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22688",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 76986449,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "GEIH_Enero_2022_Marco_2018",
+      "anomalies": []
+    },
+    {
+      "year": 2022,
+      "month": 2,
+      "catalog_id": 771,
+      "file_id": 22689,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22689",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 78538342,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "GEIH_Febrero_2022_Marco_2018.",
+      "anomalies": []
+    },
+    {
+      "year": 2022,
+      "month": 3,
+      "catalog_id": 771,
+      "file_id": 22690,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22690",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 79104573,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "GEIH_Marzo_2022_Marco_2018",
+      "anomalies": []
+    },
+    {
+      "year": 2022,
+      "month": 4,
+      "catalog_id": 771,
+      "file_id": 22894,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22894",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 78066483,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "GEIH_Abril_2022_Marco_2018",
+      "anomalies": []
+    },
+    {
+      "year": 2022,
+      "month": 5,
+      "catalog_id": 771,
+      "file_id": 22692,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22692",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 48706355,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "GEIH_Mayo_2022_Marco_2018",
+      "anomalies": []
+    },
+    {
+      "year": 2022,
+      "month": 6,
+      "catalog_id": 771,
+      "file_id": 22693,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22693",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 70590136,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "GEIH_Junio_2022_Marco_2018",
+      "anomalies": []
+    },
+    {
+      "year": 2022,
+      "month": 7,
+      "catalog_id": 771,
+      "file_id": 22694,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22694",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 68241326,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "GEIH_Julio_2022_Marco_2018",
+      "anomalies": []
+    },
+    {
+      "year": 2022,
+      "month": 8,
+      "catalog_id": 771,
+      "file_id": 22695,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22695",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 70663536,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "GEIH_Agosto_2022_Marco_2018",
+      "anomalies": []
+    },
+    {
+      "year": 2022,
+      "month": 9,
+      "catalog_id": 771,
+      "file_id": 22696,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22696",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 75990302,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "GEIH_Septiembre_Marco_2018.",
+      "anomalies": []
+    },
+    {
+      "year": 2022,
+      "month": 10,
+      "catalog_id": 771,
+      "file_id": 22697,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22697",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 71638712,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "GEIH_Octubre_Marco_2018",
+      "anomalies": []
+    },
+    {
+      "year": 2022,
+      "month": 11,
+      "catalog_id": 771,
+      "file_id": 23016,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/23016",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 72666316,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "GEIH_Noviembre_2022_Marco_2018",
+      "anomalies": []
+    },
+    {
+      "year": 2022,
+      "month": 12,
+      "catalog_id": 771,
+      "file_id": 22699,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22699",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 66521661,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "GEIH_Diciembre_2022_Marco_2018",
+      "anomalies": []
+    },
+    {
+      "year": 2023,
+      "month": 1,
+      "catalog_id": 782,
+      "file_id": 22349,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/22349",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 69122129,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Enero",
+      "anomalies": []
+    },
+    {
+      "year": 2023,
+      "month": 2,
+      "catalog_id": 782,
+      "file_id": 22466,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/22466",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 71963770,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Febrero",
+      "anomalies": []
+    },
+    {
+      "year": 2023,
+      "month": 3,
+      "catalog_id": 782,
+      "file_id": 22553,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/22553",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 74323066,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Marzo",
+      "anomalies": []
+    },
+    {
+      "year": 2023,
+      "month": 4,
+      "catalog_id": 782,
+      "file_id": 22610,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/22610",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 63847792,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Abril",
+      "anomalies": []
+    },
+    {
+      "year": 2023,
+      "month": 5,
+      "catalog_id": 782,
+      "file_id": 22819,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/22819",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 67979182,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Mayo",
+      "anomalies": []
+    },
+    {
+      "year": 2023,
+      "month": 6,
+      "catalog_id": 782,
+      "file_id": 22888,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/22888",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 68199383,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Junio",
+      "anomalies": []
+    },
+    {
+      "year": 2023,
+      "month": 7,
+      "catalog_id": 782,
+      "file_id": 22917,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/22917",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 67318579,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Julio",
+      "anomalies": []
+    },
+    {
+      "year": 2023,
+      "month": 8,
+      "catalog_id": 782,
+      "file_id": 22946,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/22946",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 70999080,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Agosto",
+      "anomalies": []
+    },
+    {
+      "year": 2023,
+      "month": 9,
+      "catalog_id": 782,
+      "file_id": 23017,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/23017",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 64592281,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Septiembre",
+      "anomalies": []
+    },
+    {
+      "year": 2023,
+      "month": 10,
+      "catalog_id": 782,
+      "file_id": 23081,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/23081",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 61404610,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Octubre",
+      "anomalies": []
+    },
+    {
+      "year": 2023,
+      "month": 11,
+      "catalog_id": 782,
+      "file_id": 23115,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/23115",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 69981962,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Noviembre",
+      "anomalies": []
+    },
+    {
+      "year": 2023,
+      "month": 12,
+      "catalog_id": 782,
+      "file_id": 23243,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/23243",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 70474792,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Diciembre",
+      "anomalies": []
+    },
+    {
+      "year": 2024,
+      "month": 1,
+      "catalog_id": 819,
+      "file_id": 23313,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23313",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 68440555,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Ene_2024",
+      "anomalies": []
+    },
+    {
+      "year": 2024,
+      "month": 2,
+      "catalog_id": 819,
+      "file_id": 23362,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23362",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 68178411,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Febrero_2024",
+      "anomalies": []
+    },
+    {
+      "year": 2024,
+      "month": 3,
+      "catalog_id": 819,
+      "file_id": 23596,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23596",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 67171778,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Marzo 2024",
+      "anomalies": []
+    },
+    {
+      "year": 2024,
+      "month": 4,
+      "catalog_id": 819,
+      "file_id": 23496,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23496",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 67821895,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Abril 2024",
+      "anomalies": []
+    },
+    {
+      "year": 2024,
+      "month": 5,
+      "catalog_id": 819,
+      "file_id": 23598,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23598",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 68555898,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Mayo_2024",
+      "anomalies": []
+    },
+    {
+      "year": 2024,
+      "month": 6,
+      "catalog_id": 819,
+      "file_id": 23625,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23625",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 66909634,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Junio_2024",
+      "anomalies": []
+    },
+    {
+      "year": 2024,
+      "month": 7,
+      "catalog_id": 819,
+      "file_id": 23631,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23631",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 69090672,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Julio_2024",
+      "anomalies": []
+    },
+    {
+      "year": 2024,
+      "month": 8,
+      "catalog_id": 819,
+      "file_id": 23651,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23651",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 62757273,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Agosto_2024",
+      "anomalies": []
+    },
+    {
+      "year": 2024,
+      "month": 9,
+      "catalog_id": 819,
+      "file_id": 23671,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23671",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 59905146,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Septiembre_2024",
+      "anomalies": []
+    },
+    {
+      "year": 2024,
+      "month": 10,
+      "catalog_id": 819,
+      "file_id": 23677,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23677",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 60125347,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Octubre_2024",
+      "anomalies": []
+    },
+    {
+      "year": 2024,
+      "month": 11,
+      "catalog_id": 819,
+      "file_id": 23729,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23729",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 59317944,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Noviembre_ 2024",
+      "anomalies": []
+    },
+    {
+      "year": 2024,
+      "month": 12,
+      "catalog_id": 819,
+      "file_id": 23794,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23794",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 57388564,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Diciembre_2024",
+      "anomalies": []
+    },
+    {
+      "year": 2025,
+      "month": 1,
+      "catalog_id": 853,
+      "file_id": 24263,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24263",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 61865984,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Enero 2025",
+      "anomalies": []
+    },
+    {
+      "year": 2025,
+      "month": 2,
+      "catalog_id": 853,
+      "file_id": 24264,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24264",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 63732449,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Febrero 2025",
+      "anomalies": []
+    },
+    {
+      "year": 2025,
+      "month": 3,
+      "catalog_id": 853,
+      "file_id": 24267,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24267",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 65148026,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Marzo 2025",
+      "anomalies": []
+    },
+    {
+      "year": 2025,
+      "month": 4,
+      "catalog_id": 853,
+      "file_id": 24269,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24269",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 64833454,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Abril 2025",
+      "anomalies": []
+    },
+    {
+      "year": 2025,
+      "month": 5,
+      "catalog_id": 853,
+      "file_id": 24268,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24268",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 66532147,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Mayo 2025",
+      "anomalies": []
+    },
+    {
+      "year": 2025,
+      "month": 6,
+      "catalog_id": 853,
+      "file_id": 24266,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24266",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 63994593,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Junio 2025.",
+      "anomalies": []
+    },
+    {
+      "year": 2025,
+      "month": 7,
+      "catalog_id": 853,
+      "file_id": 24265,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24265",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 64099450,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Julio 2025",
+      "anomalies": []
+    },
+    {
+      "year": 2025,
+      "month": 8,
+      "catalog_id": 853,
+      "file_id": 24307,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24307",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 64393052,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Agosto 2025",
+      "anomalies": []
+    },
+    {
+      "year": 2025,
+      "month": 9,
+      "catalog_id": 853,
+      "file_id": 24324,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24324",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 65263370,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Septiembre 2025",
+      "anomalies": []
+    },
+    {
+      "year": 2025,
+      "month": 10,
+      "catalog_id": 853,
+      "file_id": 24382,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24382",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 69247959,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Octubre 2025",
+      "anomalies": []
+    },
+    {
+      "year": 2025,
+      "month": 11,
+      "catalog_id": 853,
+      "file_id": 24406,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24406",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 66972549,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Noviembre 2025",
+      "anomalies": []
+    },
+    {
+      "year": 2025,
+      "month": 12,
+      "catalog_id": 853,
+      "file_id": 24463,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24463",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 63428362,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Diciembre 2025.",
+      "anomalies": []
+    },
+    {
+      "year": 2026,
+      "month": 1,
+      "catalog_id": 900,
+      "file_id": 24530,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/900/download/24530",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/900",
+      "checksum_sha256": null,
+      "size_bytes": 65567457,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Enero 2026",
+      "anomalies": []
+    },
+    {
+      "year": 2026,
+      "month": 2,
+      "catalog_id": 900,
+      "file_id": 24594,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/900/download/24594",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/900",
+      "checksum_sha256": null,
+      "size_bytes": 70632079,
+      "epoch_inferred": "geih_2021_present",
+      "file_name": "Febrero 2026",
+      "anomalies": []
+    }
+  ],
+  "gaps": [
+    {
+      "year": 2026,
+      "month": 3,
+      "reason": "Not yet published by DANE (publication lag is typically 1-2 months)"
+    },
+    {
+      "year": 2026,
+      "month": 4,
+      "reason": "Not yet published by DANE (publication lag is typically 1-2 months)"
+    },
+    {
+      "year": 2026,
+      "month": 5,
+      "reason": "Not yet published by DANE (publication lag is typically 1-2 months)"
+    }
+  ],
+  "scrape_log": {
+    "catalogs_visited": 20,
+    "geih_matches": 230,
+    "errors": [],
+    "anomalies": [
+      {
+        "catalog_id": 900,
+        "year": 2026,
+        "note": "Only 2/12 months found"
+      }
+    ],
+    "annual_catalogs_found": 20,
+    "annual_catalogs": [
+      {
+        "id": 317,
+        "year": 2007,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH 2007"
+      },
+      {
+        "id": 206,
+        "year": 2008,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2008"
+      },
+      {
+        "id": 207,
+        "year": 2009,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2009"
+      },
+      {
+        "id": 205,
+        "year": 2010,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2010"
+      },
+      {
+        "id": 182,
+        "year": 2011,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2011"
+      },
+      {
+        "id": 77,
+        "year": 2012,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2012"
+      },
+      {
+        "id": 68,
+        "year": 2013,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2013"
+      },
+      {
+        "id": 328,
+        "year": 2014,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2014"
+      },
+      {
+        "id": 356,
+        "year": 2015,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2015"
+      },
+      {
+        "id": 427,
+        "year": 2016,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2016"
+      },
+      {
+        "id": 458,
+        "year": 2017,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH -2017"
+      },
+      {
+        "id": 547,
+        "year": 2018,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2018"
+      },
+      {
+        "id": 599,
+        "year": 2019,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2019"
+      },
+      {
+        "id": 780,
+        "year": 2020,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2020"
+      },
+      {
+        "id": 701,
+        "year": 2021,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2021"
+      },
+      {
+        "id": 771,
+        "year": 2022,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2022"
+      },
+      {
+        "id": 782,
+        "year": 2023,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2023."
+      },
+      {
+        "id": 819,
+        "year": 2024,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2024."
+      },
+      {
+        "id": 853,
+        "year": 2025,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2025"
+      },
+      {
+        "id": 900,
+        "year": 2026,
+        "title": "Gran Encuesta Integrada de Hogares - GEIH - 2026"
+      }
+    ]
+  }
+}

--- a/scripts/scrape_dane_catalog.py
+++ b/scripts/scrape_dane_catalog.py
@@ -36,7 +36,6 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
 
 import requests
 from bs4 import BeautifulSoup
@@ -57,14 +56,31 @@ MAX_RETRIES = 3
 
 SPANISH_MONTHS = {
     # Full names
-    "enero": 1, "febrero": 2, "marzo": 3, "abril": 4,
-    "mayo": 5, "junio": 6, "julio": 7, "agosto": 8,
-    "septiembre": 9, "octubre": 10, "noviembre": 11, "diciembre": 12,
+    "enero": 1,
+    "febrero": 2,
+    "marzo": 3,
+    "abril": 4,
+    "mayo": 5,
+    "junio": 6,
+    "julio": 7,
+    "agosto": 8,
+    "septiembre": 9,
+    "octubre": 10,
+    "noviembre": 11,
+    "diciembre": 12,
     # Abbreviations used by DANE in newer catalogs (e.g. "Ene_2024")
-    "ene": 1, "feb": 2, "mar": 3, "abr": 4,
+    "ene": 1,
+    "feb": 2,
+    "mar": 3,
+    "abr": 4,
     # "may" omitted — ambiguous without "_" context; "mayo" already covers it
-    "jun": 6, "jul": 7, "ago": 8,
-    "sep": 9, "oct": 10, "nov": 11, "dic": 12,
+    "jun": 6,
+    "jul": 7,
+    "ago": 8,
+    "sep": 9,
+    "oct": 10,
+    "nov": 11,
+    "dic": 12,
 }
 
 # Patterns that indicate an auxiliary (non-primary) file
@@ -92,6 +108,7 @@ log = logging.getLogger(__name__)
 # HTTP helpers
 # ---------------------------------------------------------------------------
 
+
 def make_session() -> requests.Session:
     s = requests.Session()
     s.headers.update({"User-Agent": USER_AGENT})
@@ -102,7 +119,7 @@ def fetch_with_retry(
     url: str,
     session: requests.Session,
     label: str = "",
-) -> Optional[str]:
+) -> str | None:
     """Fetch URL with rate-limiting and retries. Returns HTML or None."""
     time.sleep(RATE_LIMIT_SECONDS)
     for attempt in range(MAX_RETRIES):
@@ -125,6 +142,7 @@ def fetch_with_retry(
 # ---------------------------------------------------------------------------
 # Collection discovery
 # ---------------------------------------------------------------------------
+
 
 def discover_annual_geih_catalogs(session: requests.Session) -> list[tuple[int, int, str]]:
     """Return list of (catalog_id, year, title) for main annual GEIH catalogs.
@@ -192,7 +210,8 @@ def discover_annual_geih_catalogs(session: requests.Session) -> list[tuple[int, 
 # Monthly file parsing
 # ---------------------------------------------------------------------------
 
-def parse_size_bytes(alt_text: str) -> Optional[int]:
+
+def parse_size_bytes(alt_text: str) -> int | None:
     """Parse 'Descargar [ZIP, 7.82 MB]' → bytes as int."""
     m = re.search(r"([\d.,]+)\s*(MB|GB|KB)", alt_text, re.IGNORECASE)
     if not m:
@@ -203,7 +222,7 @@ def parse_size_bytes(alt_text: str) -> Optional[int]:
     return int(value * multipliers[unit])
 
 
-def detect_month_from_name(name: str) -> Optional[int]:
+def detect_month_from_name(name: str) -> int | None:
     """Return month number (1-12) if name contains a Spanish month name.
 
     Checks full names before abbreviations to avoid false positives
@@ -212,18 +231,35 @@ def detect_month_from_name(name: str) -> Optional[int]:
     name_lower = name.lower()
     # Check full names first (sorted longest-first to avoid prefix clashes)
     full_names = [
-        ("enero", 1), ("febrero", 2), ("marzo", 3), ("abril", 4),
-        ("mayo", 5), ("junio", 6), ("julio", 7), ("agosto", 8),
-        ("septiembre", 9), ("octubre", 10), ("noviembre", 11), ("diciembre", 12),
+        ("enero", 1),
+        ("febrero", 2),
+        ("marzo", 3),
+        ("abril", 4),
+        ("mayo", 5),
+        ("junio", 6),
+        ("julio", 7),
+        ("agosto", 8),
+        ("septiembre", 9),
+        ("octubre", 10),
+        ("noviembre", 11),
+        ("diciembre", 12),
     ]
     for month_name, month_num in full_names:
         if month_name in name_lower:
             return month_num
     # Fall back to abbreviations (only if no full name matched)
     abbrevs = [
-        ("sep", 9), ("oct", 10), ("nov", 11), ("dic", 12),
-        ("ene", 1), ("feb", 2), ("mar", 3), ("abr", 4),
-        ("jun", 6), ("jul", 7), ("ago", 8),
+        ("sep", 9),
+        ("oct", 10),
+        ("nov", 11),
+        ("dic", 12),
+        ("ene", 1),
+        ("feb", 2),
+        ("mar", 3),
+        ("abr", 4),
+        ("jun", 6),
+        ("jul", 7),
+        ("ago", 8),
     ]
     for abbrev, month_num in abbrevs:
         if abbrev in name_lower:
@@ -244,7 +280,7 @@ def detect_format_priority(name: str) -> int:
         return 1
     if "." not in lower.rsplit("/", 1)[-1]:
         return 1  # no extension = likely primary SPSS/ZIP
-    if lower.endswith(".spss") or lower.endswith(".sav"):
+    if lower.endswith((".spss", ".sav")):
         return 2
     if lower.endswith(".dta"):
         return 3
@@ -266,7 +302,7 @@ def parse_microdata_files(
     spans = soup.find_all("span", class_="resource-info")
 
     # Collect all candidate files: {month_num: [(priority, file_id, name, size_bytes, url)]}
-    candidates: dict[int, list[tuple[int, str, str, Optional[int], str]]] = {}
+    candidates: dict[int, list[tuple[int, str, str, int | None, str]]] = {}
     skipped_names: list[str] = []
 
     for span in spans:
@@ -290,7 +326,7 @@ def parse_microdata_files(
 
         # Get size and URL from input button
         parent_div = span.find_parent("div", class_="resource-left-col")
-        size_bytes: Optional[int] = None
+        size_bytes: int | None = None
         download_url = f"{BASE_URL}/index.php/catalog/{catalog_id}/download/{file_id}"
 
         if parent_div:
@@ -351,7 +387,8 @@ def parse_microdata_files(
 # Epoch inference
 # ---------------------------------------------------------------------------
 
-def infer_epoch(year: int, month: int) -> str:
+
+def infer_epoch(year: int, _month: int) -> str:
     if year < 2021:
         return "geih_2006_2020"
     return "geih_2021_present"
@@ -360,6 +397,7 @@ def infer_epoch(year: int, month: int) -> str:
 # ---------------------------------------------------------------------------
 # Gap detection
 # ---------------------------------------------------------------------------
+
 
 def detect_gaps(entries: list[dict], min_year: int, max_year: int) -> list[dict]:
     """Return list of {year, month, reason} for expected but missing months."""
@@ -399,6 +437,7 @@ def _gap_reason(year: int, month: int) -> str:
 # Main scraper
 # ---------------------------------------------------------------------------
 
+
 def scrape_catalog(
     output_path: Path,
     dry_run: bool = False,
@@ -419,8 +458,12 @@ def scrape_catalog(
         log.error("No annual GEIH catalogs found. Aborting.")
         sys.exit(1)
 
-    log.info("Found %d annual GEIH catalogs: years %d-%d",
-             len(annual_catalogs), annual_catalogs[0][1], annual_catalogs[-1][1])
+    log.info(
+        "Found %d annual GEIH catalogs: years %d-%d",
+        len(annual_catalogs),
+        annual_catalogs[0][1],
+        annual_catalogs[-1][1],
+    )
 
     # Step 2: For each annual catalog, scrape monthly files
     log.info("=== Step 2: Scraping monthly files from each annual catalog ===")
@@ -434,7 +477,9 @@ def scrape_catalog(
         if html is None:
             msg = f"Failed to fetch /get_microdata for catalog {catalog_id} (year {year})"
             log.error(msg)
-            catalog_errors.append({"catalog_id": catalog_id, "year": year, "reason": "fetch_failed"})
+            catalog_errors.append(
+                {"catalog_id": catalog_id, "year": year, "reason": "fetch_failed"}
+            )
             continue
 
         entries, anomalies = parse_microdata_files(html, catalog_id, year)
@@ -453,7 +498,9 @@ def scrape_catalog(
 
         # Save partial results periodically
         if not dry_run and (i + 1) % save_interval == 0:
-            _write_partial(output_path, all_entries, catalogs_visited, catalog_errors, annual_catalogs)
+            _write_partial(
+                output_path, all_entries, catalogs_visited, catalog_errors, annual_catalogs
+            )
             log.info("Partial save after %d catalogs.", i + 1)
 
     # Step 3: Sort entries and detect gaps
@@ -479,15 +526,14 @@ def scrape_catalog(
             "anomalies": catalog_anomalies,
             "annual_catalogs_found": len(annual_catalogs),
             "annual_catalogs": [
-                {"id": cid, "year": year, "title": title}
-                for cid, year, title in annual_catalogs
+                {"id": cid, "year": year, "title": title} for cid, year, title in annual_catalogs
             ],
         },
     }
 
     if not dry_run:
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(output_path, "w", encoding="utf-8") as f:
+        with output_path.open("w", encoding="utf-8") as f:
             json.dump(result, f, indent=2, ensure_ascii=False)
         log.info("Written to %s", output_path)
 
@@ -499,7 +545,7 @@ def _write_partial(
     entries: list[dict],
     visited: int,
     errors: list[dict],
-    annual_catalogs: list[tuple[int, int, str]],
+    _annual_catalogs: list[tuple[int, int, str]],
 ) -> None:
     partial = {
         "scraped_at": datetime.now(timezone.utc).isoformat() + " (partial)",
@@ -515,13 +561,14 @@ def _write_partial(
         },
     }
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w", encoding="utf-8") as f:
+    with output_path.open("w", encoding="utf-8") as f:
         json.dump(partial, f, indent=2, ensure_ascii=False)
 
 
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(
@@ -562,7 +609,7 @@ def main() -> int:
     result = scrape_catalog(args.output, dry_run=args.dry_run)
     scrape_log = result["scrape_log"]
 
-    print(f"\nScrape complete.")
+    print("\nScrape complete.")
     print(f"  Annual catalogs found  : {scrape_log['annual_catalogs_found']}")
     print(f"  Monthly entries found  : {scrape_log['geih_matches']}")
     print(f"  Catalogs visited       : {scrape_log['catalogs_visited']}")

--- a/scripts/scrape_dane_catalog.py
+++ b/scripts/scrape_dane_catalog.py
@@ -1,0 +1,578 @@
+"""Scrape the DANE GEIH catalog and produce _scraped_catalog.json.
+
+Strategy (discovered via Phase 3.1 research):
+  DANE GEIH data is organized in ANNUAL catalogs under the MERCLAB-Microdatos
+  collection at microdatos.dane.gov.co.  Each annual catalog (e.g., 2024 → ID 819)
+  has its own /get_microdata page listing all monthly ZIP files.
+
+  This script:
+    1. Enumerates the MERCLAB-Microdatos collection pages (up to 15 pages)
+       to discover annual GEIH catalog IDs.
+    2. Filters to main annual GEIH catalogs (excludes Empalme, San Andrés,
+       Ciudades Intermedias, Módulos auxiliares, etc.).
+    3. For each annual catalog, fetches /get_microdata and parses monthly
+       file entries.
+    4. Selects a primary download file per month (CSV preferred; SPSS fallback).
+    5. Writes structured output to _scraped_catalog.json.
+
+Note: The ADR 0004 described a sequential-ID-scan strategy.  Inspection of the
+live site revealed that annual catalogs are the actual unit of organisation;
+collection enumeration is both faster and more reliable.  CATALOG_NOTES.md
+documents this deviation.
+
+Usage:
+    python scripts/scrape_dane_catalog.py --output pulso/data/_scraped_catalog.json
+    python scripts/scrape_dane_catalog.py --output ... --dry-run
+    python scripts/scrape_dane_catalog.py --output ... --verbose
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import requests
+from bs4 import BeautifulSoup
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+USER_AGENT = "pulso-catalog-scraper/0.3.1 (https://github.com/Stebandido77/pulso)"
+BASE_URL = "https://microdatos.dane.gov.co"
+COLLECTION_URL = BASE_URL + "/index.php/catalog/?collection[]=MERCLAB-Microdatos&page={page}"
+CATALOG_URL = BASE_URL + "/index.php/catalog/{cid}"
+MICRODATA_URL = BASE_URL + "/index.php/catalog/{cid}/get_microdata"
+
+RATE_LIMIT_SECONDS = 2.0
+TIMEOUT_SECONDS = 15
+MAX_RETRIES = 3
+
+SPANISH_MONTHS = {
+    # Full names
+    "enero": 1, "febrero": 2, "marzo": 3, "abril": 4,
+    "mayo": 5, "junio": 6, "julio": 7, "agosto": 8,
+    "septiembre": 9, "octubre": 10, "noviembre": 11, "diciembre": 12,
+    # Abbreviations used by DANE in newer catalogs (e.g. "Ene_2024")
+    "ene": 1, "feb": 2, "mar": 3, "abr": 4,
+    # "may" omitted — ambiguous without "_" context; "mayo" already covers it
+    "jun": 6, "jul": 7, "ago": 8,
+    "sep": 9, "oct": 10, "nov": 11, "dic": 12,
+}
+
+# Patterns that indicate an auxiliary (non-primary) file
+AUXILIARY_KEYWORDS_RE = re.compile(
+    r"total|fex|fact.?exp|proyecci|cnpv|factores|amdr|factor",
+    re.IGNORECASE,
+)
+
+# Title patterns that identify a MAIN annual GEIH catalog (not a module/special)
+MAIN_GEIH_TITLE_RE = re.compile(
+    r"gran encuesta integrada de hogares.*?geih.*?\d{4}",
+    re.IGNORECASE,
+)
+EXCLUDE_KEYWORDS_RE = re.compile(
+    r"empalme|san andr[eé]s|ciudades intermedias|m[oó]dulo|mfpt|mti|mtic"
+    r"|etnia|ciiu|factores de expansi[oó]n|nuevos departamentos|pandemia"
+    r"|anuario|semestre|trimestre",
+    re.IGNORECASE,
+)
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def make_session() -> requests.Session:
+    s = requests.Session()
+    s.headers.update({"User-Agent": USER_AGENT})
+    return s
+
+
+def fetch_with_retry(
+    url: str,
+    session: requests.Session,
+    label: str = "",
+) -> Optional[str]:
+    """Fetch URL with rate-limiting and retries. Returns HTML or None."""
+    time.sleep(RATE_LIMIT_SECONDS)
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = session.get(url, timeout=TIMEOUT_SECONDS)
+            if resp.status_code == 200:
+                return resp.text
+            if resp.status_code == 404:
+                log.debug("%s: 404 not found", label or url)
+                return None
+            log.warning("%s: HTTP %s (attempt %d)", label or url, resp.status_code, attempt + 1)
+        except requests.RequestException as exc:
+            log.warning("%s: %s (attempt %d)", label or url, exc, attempt + 1)
+        if attempt < MAX_RETRIES - 1:
+            time.sleep(2 ** (attempt + 1))
+    log.error("%s: all retries exhausted", label or url)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Collection discovery
+# ---------------------------------------------------------------------------
+
+def discover_annual_geih_catalogs(session: requests.Session) -> list[tuple[int, int, str]]:
+    """Return list of (catalog_id, year, title) for main annual GEIH catalogs.
+
+    Enumerates up to 15 pages of MERCLAB-Microdatos collection.
+    """
+    found: list[tuple[int, int, str]] = []
+    seen_ids: set[int] = set()
+
+    for page in range(1, 16):
+        url = COLLECTION_URL.format(page=page)
+        html = fetch_with_retry(url, session, f"collection page {page}")
+        if html is None:
+            log.warning("Failed to fetch collection page %d, stopping.", page)
+            break
+
+        soup = BeautifulSoup(html, "html.parser")
+        links = soup.find_all("a", href=True)
+        entries_on_page = 0
+
+        for a in links:
+            href = a["href"]
+            m = re.search(r"/catalog/(\d+)$", href)
+            if not m:
+                continue
+            cid = int(m.group(1))
+            if cid in seen_ids:
+                continue
+            seen_ids.add(cid)
+            title = a.text.strip()
+            entries_on_page += 1
+
+            if not MAIN_GEIH_TITLE_RE.search(title):
+                continue
+            if EXCLUDE_KEYWORDS_RE.search(title):
+                log.debug("Skipping non-main GEIH: ID=%d %s", cid, title)
+                continue
+
+            year_m = re.search(r"\b(20\d{2})\b", title)
+            if not year_m:
+                log.debug("No year in title: ID=%d %s", cid, title)
+                continue
+
+            year = int(year_m.group(1))
+            log.info("Annual GEIH catalog: ID=%d year=%d  %s", cid, year, title)
+            found.append((cid, year, title))
+
+        log.info("Collection page %d: %d catalog links examined", page, entries_on_page)
+        if entries_on_page == 0:
+            log.info("No entries on page %d, stopping collection scan.", page)
+            break
+
+    # Deduplicate by year — keep the one with higher catalog_id if duplicated
+    by_year: dict[int, tuple[int, int, str]] = {}
+    for cid, year, title in found:
+        if year not in by_year or cid > by_year[year][0]:
+            by_year[year] = (cid, year, title)
+
+    result = sorted(by_year.values(), key=lambda x: x[1])
+    log.info("Total main annual GEIH catalogs: %d", len(result))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Monthly file parsing
+# ---------------------------------------------------------------------------
+
+def parse_size_bytes(alt_text: str) -> Optional[int]:
+    """Parse 'Descargar [ZIP, 7.82 MB]' → bytes as int."""
+    m = re.search(r"([\d.,]+)\s*(MB|GB|KB)", alt_text, re.IGNORECASE)
+    if not m:
+        return None
+    value = float(m.group(1).replace(",", "."))
+    unit = m.group(2).upper()
+    multipliers = {"KB": 1024, "MB": 1024**2, "GB": 1024**3}
+    return int(value * multipliers[unit])
+
+
+def detect_month_from_name(name: str) -> Optional[int]:
+    """Return month number (1-12) if name contains a Spanish month name.
+
+    Checks full names before abbreviations to avoid false positives
+    (e.g., "enero" must be matched before "ene").
+    """
+    name_lower = name.lower()
+    # Check full names first (sorted longest-first to avoid prefix clashes)
+    full_names = [
+        ("enero", 1), ("febrero", 2), ("marzo", 3), ("abril", 4),
+        ("mayo", 5), ("junio", 6), ("julio", 7), ("agosto", 8),
+        ("septiembre", 9), ("octubre", 10), ("noviembre", 11), ("diciembre", 12),
+    ]
+    for month_name, month_num in full_names:
+        if month_name in name_lower:
+            return month_num
+    # Fall back to abbreviations (only if no full name matched)
+    abbrevs = [
+        ("sep", 9), ("oct", 10), ("nov", 11), ("dic", 12),
+        ("ene", 1), ("feb", 2), ("mar", 3), ("abr", 4),
+        ("jun", 6), ("jul", 7), ("ago", 8),
+    ]
+    for abbrev, month_num in abbrevs:
+        if abbrev in name_lower:
+            return month_num
+    return None
+
+
+def detect_format_priority(name: str) -> int:
+    """Lower = more preferred. CSV > no-extension ZIP > SPSS > Stata > TXT.
+
+    Trailing dots/spaces in file names (e.g. "Mayo.csv.") are stripped before
+    checking the suffix to handle DANE's occasional naming inconsistencies.
+    """
+    lower = name.strip(". ").lower()
+    if lower.endswith(".csv"):
+        return 0
+    if lower.endswith(".zip"):
+        return 1
+    if "." not in lower.rsplit("/", 1)[-1]:
+        return 1  # no extension = likely primary SPSS/ZIP
+    if lower.endswith(".spss") or lower.endswith(".sav"):
+        return 2
+    if lower.endswith(".dta"):
+        return 3
+    if lower.endswith(".txt"):
+        return 4
+    return 5
+
+
+def parse_microdata_files(
+    html: str,
+    catalog_id: int,
+    year: int,
+) -> tuple[list[dict], list[str]]:
+    """Parse /get_microdata HTML and return (monthly_entries, anomalies).
+
+    Returns one entry per month found, selecting the primary download file.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    spans = soup.find_all("span", class_="resource-info")
+
+    # Collect all candidate files: {month_num: [(priority, file_id, name, size_bytes, url)]}
+    candidates: dict[int, list[tuple[int, str, str, Optional[int], str]]] = {}
+    skipped_names: list[str] = []
+
+    for span in spans:
+        file_id = span.get("id", "").strip()
+        raw_name = span.text.strip()
+
+        if not file_id:
+            continue
+
+        # Check if auxiliary
+        if AUXILIARY_KEYWORDS_RE.search(raw_name):
+            log.debug("  Skipping auxiliary file: %s (id=%s)", raw_name, file_id)
+            skipped_names.append(raw_name)
+            continue
+
+        month_num = detect_month_from_name(raw_name)
+        if month_num is None:
+            log.debug("  No month in file name: %s", raw_name)
+            skipped_names.append(raw_name)
+            continue
+
+        # Get size and URL from input button
+        parent_div = span.find_parent("div", class_="resource-left-col")
+        size_bytes: Optional[int] = None
+        download_url = f"{BASE_URL}/index.php/catalog/{catalog_id}/download/{file_id}"
+
+        if parent_div:
+            inp = parent_div.find("input")
+            if inp:
+                alt = inp.get("alt", "")
+                size_bytes = parse_size_bytes(alt)
+                onclick = inp.get("onclick", "")
+                url_m = re.search(r"'(https://[^']+)'", onclick)
+                if url_m:
+                    download_url = url_m.group(1).strip()
+
+        priority = detect_format_priority(raw_name)
+        candidates.setdefault(month_num, []).append(
+            (priority, file_id, raw_name, size_bytes, download_url)
+        )
+
+    # Build one entry per month, selecting the best-priority file
+    entries = []
+    anomalies = []
+
+    for month_num in sorted(candidates.keys()):
+        files = sorted(candidates[month_num], key=lambda x: x[0])
+        best = files[0]
+        priority, file_id, name, size_bytes, download_url = best
+
+        epoch = infer_epoch(year, month_num)
+        entry: dict = {
+            "year": year,
+            "month": month_num,
+            "catalog_id": catalog_id,
+            "file_id": int(file_id),
+            "download_url": download_url,
+            "landing_page": CATALOG_URL.format(cid=catalog_id),
+            "checksum_sha256": None,
+            "size_bytes": size_bytes,
+            "epoch_inferred": epoch,
+            "file_name": name,
+            "anomalies": [],
+        }
+
+        if len(files) > 1:
+            alt_formats = [f[2] for f in files[1:]]
+            note = f"Multiple formats available: {', '.join(alt_formats)}"
+            entry["anomalies"].append(note)
+            log.debug("  Month %d: selected %s (alternatives: %s)", month_num, name, alt_formats)
+
+        entries.append(entry)
+        log.info("  Month %02d: %s  size=%s", month_num, name, size_bytes)
+
+    if not entries:
+        anomalies.append(f"No monthly files parsed from catalog {catalog_id}")
+
+    return entries, anomalies
+
+
+# ---------------------------------------------------------------------------
+# Epoch inference
+# ---------------------------------------------------------------------------
+
+def infer_epoch(year: int, month: int) -> str:
+    if year < 2021:
+        return "geih_2006_2020"
+    return "geih_2021_present"
+
+
+# ---------------------------------------------------------------------------
+# Gap detection
+# ---------------------------------------------------------------------------
+
+def detect_gaps(entries: list[dict], min_year: int, max_year: int) -> list[dict]:
+    """Return list of {year, month, reason} for expected but missing months."""
+    present: set[tuple[int, int]] = {(e["year"], e["month"]) for e in entries}
+    gaps = []
+    today = datetime.now(timezone.utc)
+    current_year, current_month = today.year, today.month
+
+    for year in range(min_year, max_year + 1):
+        start_month = 8 if year == 2006 else 1  # GEIH started Aug 2006
+        for month in range(start_month, 13):
+            # Don't flag future months as gaps
+            if (year, month) > (current_year, current_month):
+                break
+            if (year, month) not in present:
+                reason = _gap_reason(year, month)
+                gaps.append({"year": year, "month": month, "reason": reason})
+
+    return gaps
+
+
+def _gap_reason(year: int, month: int) -> str:
+    """Best-effort explanation for known gaps."""
+    today = datetime.now(timezone.utc)
+    # DANE publishes with ~2 month lag; recent months are not yet available
+    months_since = (today.year - year) * 12 + (today.month - month)
+    if 0 <= months_since <= 2:
+        return "Not yet published by DANE (publication lag is typically 1-2 months)"
+    if year == 2020 and month in (4, 5):
+        return "DANE suspended in-person operations due to COVID-19 pandemic"
+    if year == 2006:
+        return "GEIH 2006 (Aug-Dec) microdata not published in MERCLAB catalog"
+    return "Month not found in DANE MERCLAB catalog (scraping may need retry)"
+
+
+# ---------------------------------------------------------------------------
+# Main scraper
+# ---------------------------------------------------------------------------
+
+def scrape_catalog(
+    output_path: Path,
+    dry_run: bool = False,
+    save_interval: int = 5,
+) -> dict:
+    """Discover and scrape all main annual GEIH catalogs."""
+    session = make_session()
+    all_entries: list[dict] = []
+    catalog_errors: list[dict] = []
+    catalog_anomalies: list[dict] = []
+    catalogs_visited = 0
+
+    # Step 1: Discover annual GEIH catalogs from MERCLAB collection
+    log.info("=== Step 1: Discovering annual GEIH catalogs from MERCLAB collection ===")
+    annual_catalogs = discover_annual_geih_catalogs(session)
+
+    if not annual_catalogs:
+        log.error("No annual GEIH catalogs found. Aborting.")
+        sys.exit(1)
+
+    log.info("Found %d annual GEIH catalogs: years %d-%d",
+             len(annual_catalogs), annual_catalogs[0][1], annual_catalogs[-1][1])
+
+    # Step 2: For each annual catalog, scrape monthly files
+    log.info("=== Step 2: Scraping monthly files from each annual catalog ===")
+    for i, (catalog_id, year, title) in enumerate(annual_catalogs):
+        log.info("[%d/%d] Catalog %d: %s", i + 1, len(annual_catalogs), catalog_id, title)
+
+        url = MICRODATA_URL.format(cid=catalog_id)
+        html = fetch_with_retry(url, session, f"catalog {catalog_id} /get_microdata")
+        catalogs_visited += 1
+
+        if html is None:
+            msg = f"Failed to fetch /get_microdata for catalog {catalog_id} (year {year})"
+            log.error(msg)
+            catalog_errors.append({"catalog_id": catalog_id, "year": year, "reason": "fetch_failed"})
+            continue
+
+        entries, anomalies = parse_microdata_files(html, catalog_id, year)
+        all_entries.extend(entries)
+
+        if anomalies:
+            for anomaly in anomalies:
+                log.warning("Catalog %d: %s", catalog_id, anomaly)
+                catalog_anomalies.append({"catalog_id": catalog_id, "year": year, "note": anomaly})
+
+        month_count = len(entries)
+        if month_count < 12:
+            note = f"Only {month_count}/12 months found"
+            log.info("  Warning: %s", note)
+            catalog_anomalies.append({"catalog_id": catalog_id, "year": year, "note": note})
+
+        # Save partial results periodically
+        if not dry_run and (i + 1) % save_interval == 0:
+            _write_partial(output_path, all_entries, catalogs_visited, catalog_errors, annual_catalogs)
+            log.info("Partial save after %d catalogs.", i + 1)
+
+    # Step 3: Sort entries and detect gaps
+    all_entries.sort(key=lambda e: (e["year"], e["month"]))
+
+    min_year = annual_catalogs[0][1] if annual_catalogs else 2007
+    max_year = annual_catalogs[-1][1] if annual_catalogs else 2026
+    gaps = detect_gaps(all_entries, min_year, max_year)
+    if gaps:
+        log.info("Detected %d gaps in the catalog", len(gaps))
+
+    # Build final output
+    result = {
+        "scraped_at": datetime.now(timezone.utc).isoformat(),
+        "scraped_by": "scripts/scrape_dane_catalog.py",
+        "schema_version": "0.1.0",
+        "entries": all_entries,
+        "gaps": gaps,
+        "scrape_log": {
+            "catalogs_visited": catalogs_visited,
+            "geih_matches": len(all_entries),
+            "errors": catalog_errors,
+            "anomalies": catalog_anomalies,
+            "annual_catalogs_found": len(annual_catalogs),
+            "annual_catalogs": [
+                {"id": cid, "year": year, "title": title}
+                for cid, year, title in annual_catalogs
+            ],
+        },
+    }
+
+    if not dry_run:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(result, f, indent=2, ensure_ascii=False)
+        log.info("Written to %s", output_path)
+
+    return result
+
+
+def _write_partial(
+    output_path: Path,
+    entries: list[dict],
+    visited: int,
+    errors: list[dict],
+    annual_catalogs: list[tuple[int, int, str]],
+) -> None:
+    partial = {
+        "scraped_at": datetime.now(timezone.utc).isoformat() + " (partial)",
+        "scraped_by": "scripts/scrape_dane_catalog.py",
+        "schema_version": "0.1.0",
+        "entries": sorted(entries, key=lambda e: (e["year"], e["month"])),
+        "gaps": [],
+        "scrape_log": {
+            "catalogs_visited": visited,
+            "geih_matches": len(entries),
+            "errors": errors,
+            "partial": True,
+        },
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(partial, f, indent=2, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Scrape DANE GEIH annual catalogs and produce _scraped_catalog.json",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Path to write _scraped_catalog.json",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Scrape but do not write output file",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable DEBUG logging",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    log.info("pulso DANE catalog scraper starting")
+    log.info("Output: %s", args.output)
+    if args.dry_run:
+        log.info("DRY RUN — no file will be written")
+
+    result = scrape_catalog(args.output, dry_run=args.dry_run)
+    scrape_log = result["scrape_log"]
+
+    print(f"\nScrape complete.")
+    print(f"  Annual catalogs found  : {scrape_log['annual_catalogs_found']}")
+    print(f"  Monthly entries found  : {scrape_log['geih_matches']}")
+    print(f"  Catalogs visited       : {scrape_log['catalogs_visited']}")
+    print(f"  Errors                 : {len(scrape_log['errors'])}")
+    print(f"  Gaps detected          : {len(result['gaps'])}")
+    if not args.dry_run:
+        print(f"  Output written to      : {args.output}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Sprint 3.1 of Phase 3 (cobertura amplia 2006-presente). Discovers and documents the complete DANE GEIH catalog, enabling Phase 3.2 to populate `sources.json` deterministically.

- **ADR 0004** (`docs/adr/0004-dane-catalog-scraping.md`): catalog scraping strategy
- **Scraper** (`scripts/scrape_dane_catalog.py`): enumerates MERCLAB-Microdatos collection (9 pages), visits each annual GEIH catalog's `/get_microdata` page, extracts monthly files
- **Catalog** (`pulso/data/_scraped_catalog.json`): 230 GEIH monthly entries, 2007-01 to 2026-02, 0 errors
- **Findings** (`docs/CATALOG_NOTES.md`): 2006 gap, COVID anomaly, 2022 redesign, epoch boundary note, Phase 3.2 recommendations

## Key findings

- **230 monthly entries**, January 2007 – February 2026, all 19 full years complete (12/12 months each)
- **3 gaps**: March–May 2026 not yet published by DANE (2-month publication lag)
- **GEIH 2006 (Aug–Dec) does not exist** in the MERCLAB portal — earliest microdata is January 2007, despite GEIH field operations starting August 7, 2006
- **2020 COVID**: April–July 2020 files are 50–65% smaller (telephone-only sample); data exists but coverage is reduced
- **2022 redesign**: GEIH Marco 2018 deployed January 2022; file sizes jump from ~6 MB to ~67 MB
- **Regression**: `2024-06` download URL in `_scraped_catalog.json` matches `sources.json` exactly ✓

## Strategy deviation from ADR 0004

ADR 0004 described sequential catalog-ID scanning (~800 IDs, ~30 min). Inspection of the live DANE portal revealed GEIH is organized in annual catalogs under the MERCLAB-Microdatos collection. Collection enumeration (9 pages → 20 annual catalogs) completes in ~60 seconds. The ADR remains as written (it was pre-approved verbatim); the deviation is documented in CATALOG_NOTES.md.

## Out of scope (subsequent sprints)

- Modifying `sources.json` (Phase 3.2)
- Downloading actual ZIP files (Phase 3.4)
- Modifying `pulso/_core/`

## Closes #21