### PR TITLE
data(epochs): correct boundary from 2021-01 to 2022-01

### DIFF
--- a/docs/CATALOG_NOTES.md
+++ b/docs/CATALOG_NOTES.md
@@ -260,3 +260,33 @@ maintainable (DANE adding new surveys doesn't affect the scan). The committed
 6. **Check `checksum_sha256`**: Currently `null` for all entries — DANE does not
    publish checksums on the get_microdata page. The validate step in Phase 3.2
    should compute checksums after downloading a sample.
+
+
+## Update 2026-05-01: Epoch Boundary Correction
+
+After Phase 3.1 was merged, the Phase 3.2 strategic spike (downloading 4 ZIPs from 2007-12, 2015-06, 2021-06, 2022-01) provided empirical evidence that the GEIH file format break is **January 2022**, not January 2021 as initially assumed.
+
+### Evidence
+
+| Month | Size (MB) | File format | Epoch |
+|---|---|---|---|
+| 2007-12 | 6.4 | Shape A (CSV simple) | geih_2006_2020 |
+| 2015-06 | 6.7 | Shape A | geih_2006_2020 |
+| 2021-06 | 6.2 | Shape A | geih_2006_2020 (corrected) |
+| 2022-01 | 77 | Shape B (Marco 2018) | geih_2021_present |
+
+The 2021 files retain the old format despite DANE's documented methodological redesign date being 2021. The actual file format transition occurred 12 months later when the 2018 sampling frame was deployed in production.
+
+### Impact
+
+- `pulso/data/epochs.json`: `geih_2006_2020.date_range` extended from `[2006-01, 2020-12]` to `[2006-01, 2021-12]`. `geih_2021_present.date_range` shifted from `[2021-01, null]` to `[2022-01, null]`.
+- `scripts/scrape_dane_catalog.py`: `infer_epoch()` updated from `year < 2021` to `year < 2022`.
+- `pulso/data/_scraped_catalog.json`: regenerated. 12 entries (2021-01 through 2021-12) reclassified from `geih_2021_present` to `geih_2006_2020`.
+- Tests: `test_epoch_for_month_2021_01_boundary` removed (no longer a boundary). Added `test_epoch_for_month_2022_01_boundary`, `test_epoch_for_month_2021_12_is_geih2006`, `test_epoch_for_month_2021_06_is_geih2006`.
+
+### Final distribution
+
+- `geih_2006_2020`: 180 entries (2007-01 through 2021-12)
+- `geih_2021_present`: 50 entries (2022-01 through 2026-02)
+
+The epoch key name `geih_2021_present` is intentionally retained despite being technically misleading. Renaming to `geih_2022_present` would touch ~170 references across code, tests, and data files. The key is an internal identifier; the date_range is the source of truth.

--- a/pulso/data/_scraped_catalog.json
+++ b/pulso/data/_scraped_catalog.json
@@ -1,5 +1,5 @@
 {
-  "scraped_at": "2026-05-01T06:06:52.660123+00:00",
+  "scraped_at": "2026-05-01T06:49:28.328748+00:00",
   "scraped_by": "scripts/scrape_dane_catalog.py",
   "schema_version": "0.1.0",
   "entries": [
@@ -2508,7 +2508,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
       "checksum_sha256": null,
       "size_bytes": 5463080,
-      "epoch_inferred": "geih_2021_present",
+      "epoch_inferred": "geih_2006_2020",
       "file_name": "Enero.csv",
       "anomalies": [
         "Multiple formats available: Enero.spss, Enero.dta"
@@ -2523,7 +2523,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
       "checksum_sha256": null,
       "size_bytes": 5494538,
-      "epoch_inferred": "geih_2021_present",
+      "epoch_inferred": "geih_2006_2020",
       "file_name": "Febrero.csv.",
       "anomalies": [
         "Multiple formats available: Febrero.spss, Febrero.dta."
@@ -2538,7 +2538,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
       "checksum_sha256": null,
       "size_bytes": 5400166,
-      "epoch_inferred": "geih_2021_present",
+      "epoch_inferred": "geih_2006_2020",
       "file_name": "Marzo.csv",
       "anomalies": [
         "Multiple formats available: Marzo.spss., Marzo.dta, GEIH_2021_Marco_2018 (II.Semestre)., GEIH_Marco_2018 (I.Semestre)."
@@ -2553,7 +2553,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
       "checksum_sha256": null,
       "size_bytes": 5546967,
-      "epoch_inferred": "geih_2021_present",
+      "epoch_inferred": "geih_2006_2020",
       "file_name": "Abril.csv.",
       "anomalies": [
         "Multiple formats available: Abril.spss, Abril.dta."
@@ -2568,7 +2568,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
       "checksum_sha256": null,
       "size_bytes": 6627000,
-      "epoch_inferred": "geih_2021_present",
+      "epoch_inferred": "geih_2006_2020",
       "file_name": "Mayo.csv",
       "anomalies": [
         "Multiple formats available: Mayo.spss, Mayo.dta"
@@ -2583,7 +2583,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
       "checksum_sha256": null,
       "size_bytes": 6176112,
-      "epoch_inferred": "geih_2021_present",
+      "epoch_inferred": "geih_2006_2020",
       "file_name": "Junio.csv",
       "anomalies": [
         "Multiple formats available: Junio.sav, Junio.dta"
@@ -2598,7 +2598,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
       "checksum_sha256": null,
       "size_bytes": 6910115,
-      "epoch_inferred": "geih_2021_present",
+      "epoch_inferred": "geih_2006_2020",
       "file_name": "Julio.csv",
       "anomalies": [
         "Multiple formats available: Julio.spss, Julio.dta"
@@ -2613,7 +2613,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
       "checksum_sha256": null,
       "size_bytes": 6574571,
-      "epoch_inferred": "geih_2021_present",
+      "epoch_inferred": "geih_2006_2020",
       "file_name": "Agosto.csv",
       "anomalies": [
         "Multiple formats available: Agosto.spss, Agosto.dta"
@@ -2628,7 +2628,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
       "checksum_sha256": null,
       "size_bytes": 6490685,
-      "epoch_inferred": "geih_2021_present",
+      "epoch_inferred": "geih_2006_2020",
       "file_name": "Septiembre.csv",
       "anomalies": [
         "Multiple formats available: Septiembre.spss, Septiembre.dta"
@@ -2643,7 +2643,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
       "checksum_sha256": null,
       "size_bytes": 6291456,
-      "epoch_inferred": "geih_2021_present",
+      "epoch_inferred": "geih_2006_2020",
       "file_name": "Octubre.csv",
       "anomalies": [
         "Multiple formats available: Octubre.spss, Octubre.dta"
@@ -2658,7 +2658,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
       "checksum_sha256": null,
       "size_bytes": 5987368,
-      "epoch_inferred": "geih_2021_present",
+      "epoch_inferred": "geih_2006_2020",
       "file_name": "Noviembre.csv",
       "anomalies": [
         "Multiple formats available: Noviembre.spss, Noviembre.dta"
@@ -2673,7 +2673,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
       "checksum_sha256": null,
       "size_bytes": 5924454,
-      "epoch_inferred": "geih_2021_present",
+      "epoch_inferred": "geih_2006_2020",
       "file_name": "Diciembre.csv",
       "anomalies": [
         "Multiple formats available: Diciembre.spss, Diciembre.dta"

--- a/pulso/data/epochs.json
+++ b/pulso/data/epochs.json
@@ -1,22 +1,35 @@
 {
   "metadata": {
     "schema_version": "1.1.0",
-    "last_updated": "2026-04-28T00:00:00Z"
+    "last_updated": "2026-05-01T06:40:22.943262+00:00"
   },
   "epochs": {
     "geih_2006_2020": {
       "label": "GEIH marco muestral 2005",
       "label_en": "GEIH 2005 sampling frame",
-      "date_range": ["2006-01", "2020-12"],
+      "date_range": [
+        "2006-01",
+        "2021-12"
+      ],
       "merge_keys": {
-        "persona": ["DIRECTORIO", "SECUENCIA_P", "ORDEN"],
-        "hogar": ["DIRECTORIO", "SECUENCIA_P"]
+        "persona": [
+          "DIRECTORIO",
+          "SECUENCIA_P",
+          "ORDEN"
+        ],
+        "hogar": [
+          "DIRECTORIO",
+          "SECUENCIA_P"
+        ]
       },
       "encoding": "latin-1",
       "file_format": "csv",
       "separator": ";",
       "decimal": ",",
-      "folder_pattern": ["Cabecera/", "Resto/"],
+      "folder_pattern": [
+        "Cabecera/",
+        "Resto/"
+      ],
       "weight_variable": "fex_c_2011",
       "area_filter": null,
       "notes_es": "Operativo continuo mensual desde enero 2006. Marco muestral del Censo 2005. Reemplazó a la Encuesta Continua de Hogares (ECH) que cubría 2000-2005, no incluida en este paquete por discontinuidades metodológicas mayores. Cada módulo se entrega como dos archivos separados (Cabecera/ y Resto/).",
@@ -26,21 +39,38 @@
     "geih_2021_present": {
       "label": "GEIH rediseñada (post-OIT, marco 2018)",
       "label_en": "Redesigned GEIH (post-ILO, 2018 frame)",
-      "date_range": ["2021-01", null],
+      "date_range": [
+        "2022-01",
+        null
+      ],
       "merge_keys": {
-        "persona": ["DIRECTORIO", "SECUENCIA_P", "ORDEN"],
-        "hogar": ["DIRECTORIO", "SECUENCIA_P"]
+        "persona": [
+          "DIRECTORIO",
+          "SECUENCIA_P",
+          "ORDEN"
+        ],
+        "hogar": [
+          "DIRECTORIO",
+          "SECUENCIA_P"
+        ]
       },
       "encoding": "latin-1",
       "file_format": "csv",
       "separator": ";",
       "decimal": ",",
-      "folder_pattern": ["CSV/"],
+      "folder_pattern": [
+        "CSV/"
+      ],
       "weight_variable": "FEX_C18",
       "area_filter": {
         "column": "CLASE",
-        "cabecera_values": [1],
-        "resto_values": [2, 3]
+        "cabecera_values": [
+          1
+        ],
+        "resto_values": [
+          2,
+          3
+        ]
       },
       "notes_es": "Rediseño metodológico aplicando recomendaciones de la 19ª CIET (OIT, 2013). Marco muestral del Censo Nacional de Población y Vivienda 2018. Discontinuidad documentada con la GEIH 2006-2020 en variables clave de mercado laboral. Cada módulo se entrega como un único archivo nacional; el split urbano/rural se hace filtrando la columna CLASE (1=cabecera, 2=centro poblado, 3=rural disperso).",
       "notes_en": "Methodological redesign applying 19th ICLS (ILO, 2013) recommendations. 2018 Census sampling frame. Documented discontinuity with the 2006-2020 GEIH on key labor market variables. Each module is delivered as a single nationwide file; urban/rural split is applied by filtering the CLASE column (1=cabecera, 2=centro poblado, 3=rural disperso).",

--- a/scripts/scrape_dane_catalog.py
+++ b/scripts/scrape_dane_catalog.py
@@ -389,7 +389,7 @@ def parse_microdata_files(
 
 
 def infer_epoch(year: int, _month: int) -> str:
-    if year < 2021:
+    if year < 2022:
         return "geih_2006_2020"
     return "geih_2021_present"
 

--- a/tests/unit/test_epochs.py
+++ b/tests/unit/test_epochs.py
@@ -15,7 +15,7 @@ def test_get_epoch_geih_2021_present() -> None:
     assert e.file_format == "csv"
     assert e.separator == ";"
     assert e.decimal == ","
-    assert e.date_range[0] == "2021-01"
+    assert e.date_range[0] == "2022-01"
     assert e.date_range[1] is None  # open-ended
 
 
@@ -27,7 +27,7 @@ def test_get_epoch_geih_2006_2020() -> None:
     assert e.key == "geih_2006_2020"
     assert e.encoding == "latin-1"
     assert e.date_range[0] == "2006-01"
-    assert e.date_range[1] == "2020-12"
+    assert e.date_range[1] == "2021-12"
 
 
 def test_get_epoch_unknown_raises_config_error() -> None:
@@ -86,12 +86,32 @@ def test_epoch_for_month_2020_12_is_geih2006() -> None:
     assert e.key == "geih_2006_2020"
 
 
-def test_epoch_for_month_2021_01_boundary() -> None:
-    """2021-01 is the first month of the new epoch."""
+def test_epoch_for_month_2022_01_boundary() -> None:
+    """2022-01 is the first month of the new epoch (file format break with Marco 2018)."""
     from pulso._config.epochs import epoch_for_month
 
-    e = epoch_for_month(2021, 1)
+    e = epoch_for_month(2022, 1)
     assert e.key == "geih_2021_present"
+
+
+def test_epoch_for_month_2021_12_is_geih2006() -> None:
+    """2021-12 is still in the old epoch (file format break is 2022-01, not 2021-01)."""
+    from pulso._config.epochs import epoch_for_month
+
+    e = epoch_for_month(2021, 12)
+    assert e.key == "geih_2006_2020"
+
+
+def test_epoch_for_month_2021_06_is_geih2006() -> None:
+    """Regression: 2021-06 must fall in geih_2006_2020 (old format ~6MB), not geih_2021_present.
+
+    Empirically validated in Phase 3.2 spike: 2021-06 ZIP is 6.2 MB (Shape A old format),
+    while 2022-01 is 77 MB (Shape B Marco 2018 redesign).
+    """
+    from pulso._config.epochs import epoch_for_month
+
+    e = epoch_for_month(2021, 6)
+    assert e.key == "geih_2006_2020"
 
 
 def test_epoch_for_month_2006_01_boundary() -> None:


### PR DESCRIPTION
Empirical correction of the epoch boundary based on Phase 3.2 strategic spike.

## Evidence

- 2007-12: 6.4 MB Shape A (geih_2006_2020)
- 2015-06: 6.7 MB Shape A (geih_2006_2020)
- 2021-06: 6.2 MB Shape A (geih_2006_2020 - corrected, was geih_2021_present)
- 2022-01: 77 MB Shape B Marco 2018 (geih_2021_present)

## Changes

- pulso/data/epochs.json: date_range corrected for both epochs
- scripts/scrape_dane_catalog.py: infer_epoch boundary year < 2022
- pulso/data/_scraped_catalog.json: regenerated (12 entries reclassified)
- tests/unit/test_epochs.py: 1 obsolete test replaced with 3 new tests
- docs/CATALOG_NOTES.md: addendum documenting the empirical evidence

## Verification

- pytest: 149 passed, 17 skipped, 0 failed
- Phase 2 regression: load_merged(2024, 6) produces shape (70020, 525) as before
- ruff + ruff format + json validation: all pass

## Final epoch distribution

- geih_2006_2020: 180 entries (2007-01 to 2021-12)
- geih_2021_present: 50 entries (2022-01 to 2026-02)

## Note on naming

The key name `geih_2021_present` is intentionally retained despite being technically misleading. Renaming would touch ~170 references across code, tests, and data. The key is an internal identifier; the date_range is the source of truth.

Closes #23