### PR TITLE
Phase 3.2.C: sources.json scaled to 230 entries

### DIFF
--- a/docs/PHASE_3_DATA_NOTES.md
+++ b/docs/PHASE_3_DATA_NOTES.md
@@ -1,0 +1,77 @@
+# Phase 3 Data Notes
+
+## Phase 3.2.C: sources.json scaled to 230 entries
+
+### Scale
+
+| | Before | After |
+|--|--------|-------|
+| Entries | 1 (2024-06, Phase 1 manual) | 230 (2007-01 to 2026-02) |
+| Shape A (geih_2006_2020) | 0 | 180 |
+| Shape B (geih_2021_present) | 0 | 50 |
+
+### Generation
+
+Deterministic from `pulso/data/_scraped_catalog.json` via:
+
+```bash
+python scripts/generate_sources_from_catalog.py \
+    --catalog pulso/data/_scraped_catalog.json \
+    --output pulso/data/sources.json
+```
+
+The generator is idempotent: re-running produces the same output (given the same catalog).
+
+### Decisions
+
+#### Schema change: `checksum_sha256` made nullable
+
+DANE does not publish checksums on their microdata portal. All 229 new entries have
+`checksum_sha256: null`. The existing 2024-06 entry retains its manually computed
+checksum. Phase 3.4 will populate real checksums for each entry after downloading
+the ZIP files.
+
+#### Canonical filenames declared (not actual disk filenames)
+
+`sources.json` declares the expected canonical names (e.g.
+`"Cabecera - Características generales (Personas).csv"`). The Shape A parser
+(`is_shape_a` + `find_shape_a_files` in `pulso/_core/parser.py`) tolerates
+real-world DANE filename variations via keyword matching:
+- Missing accents: `"Caracteristicas generales"` vs `"Características generales"`
+- 2007 typo: `"Caractericas generales"` (missing 't')
+- Spacing: `"Cabecera-"` vs `"Cabecera - "`
+
+Phase 3.3 (real-data validation) will confirm actual filenames and flag any that
+don't match. No changes to `sources.json` are expected unless a module is entirely
+missing from some year's ZIP.
+
+#### 2024-06 entry preserved
+
+The Phase 1 manually validated entry (with a real checksum, `validated: true`,
+`validated_by: "manual"`) is preserved unchanged. The generator detects
+`validated: true` and skips regeneration.
+
+#### Shape A entries get 6 modules
+
+GEIH-1 (2007-2021) does not have the `migracion` or `otras_formas_trabajo`
+modules (introduced in GEIH-2 in 2022). The `available_in` field in
+`CANONICAL_MODULES` enforces this — Shape A entries receive only the 6 modules
+whose `available_in` list includes `"geih_2006_2020"`.
+
+#### Shape B entries get 8 modules
+
+GEIH-2 (2022-2026) includes all 8 canonical modules. File paths verified against
+the 2024-06 ZIP (the only validated entry at this point).
+
+#### row_filter omitted for new Shape B entries
+
+`desocupados` and `inactivos` share `"CSV/No ocupados.CSV"` without `row_filter`.
+This matches the existing 2024-06 pattern. Phase 3.4 (real-data validation) will
+confirm the OCI column values and add `row_filter` if needed.
+
+### Out of scope (subsequent sprints)
+
+- Downloading any ZIP file (Phase 3.4)
+- Computing real checksums (Phase 3.4)
+- Verifying that all 230 entries load without errors (Phase 3.3)
+- Adding `row_filter` for desocupados/inactivos after confirming OCI (Phase 3.4)

--- a/pulso/data/schemas/sources.schema.json
+++ b/pulso/data/schemas/sources.schema.json
@@ -91,9 +91,14 @@
           "description": "URL to the DANE catalog page describing this dataset."
         },
         "checksum_sha256": {
-          "type": "string",
-          "pattern": "^[a-f0-9]{64}$",
-          "description": "SHA-256 hex digest of the downloaded ZIP."
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-f0-9]{64}$"
+            },
+            { "type": "null" }
+          ],
+          "description": "SHA-256 hex digest of the downloaded ZIP. Null when DANE does not publish a checksum (default for most entries; Phase 3.4 fills with computed checksums)."
         },
         "size_bytes": {
           "type": ["integer", "null"],

--- a/pulso/data/sources.json
+++ b/pulso/data/sources.json
@@ -2,61 +2,8028 @@
   "metadata": {
     "schema_version": "1.1.0",
     "data_version": "2026.04",
-    "last_updated": "2026-04-28T00:00:00Z",
-    "scraper_version": null,
-    "covered_range": ["2024-06", "2024-06"]
+    "last_updated": "2026-05-01T07:36:20Z",
+    "scraper_version": "generate_sources_from_catalog/0.1.0",
+    "covered_range": [
+      "2007-01",
+      "2026-02"
+    ]
   },
   "modules": {
     "caracteristicas_generales": {
       "level": "persona",
-      "description_es": "Características generales: sexo, edad, parentesco, estado civil, etnia, nivel educativo.",
-      "description_en": "General characteristics: sex, age, kinship, marital status, ethnicity, education level.",
-      "available_in": ["geih_2006_2020", "geih_2021_present"]
+      "description_es": "Características demográficas, educativas y de salud de las personas.",
+      "description_en": "Demographic, educational, and health characteristics of persons.",
+      "available_in": [
+        "geih_2006_2020",
+        "geih_2021_present"
+      ]
     },
     "ocupados": {
       "level": "persona",
-      "description_es": "Personas ocupadas: posición ocupacional, rama de actividad, ingresos laborales, formalidad.",
-      "description_en": "Employed persons: occupational position, branch of activity, labor income, formality.",
-      "available_in": ["geih_2006_2020", "geih_2021_present"]
+      "description_es": "Información laboral de las personas ocupadas en la semana de referencia.",
+      "description_en": "Labor market information for employed persons in the reference week.",
+      "available_in": [
+        "geih_2006_2020",
+        "geih_2021_present"
+      ]
     },
     "desocupados": {
       "level": "persona",
-      "description_es": "Personas desocupadas y fuerza de trabajo: búsqueda de empleo, tiempo desempleado.",
-      "description_en": "Unemployed persons and labor force: job search, unemployment duration.",
-      "available_in": ["geih_2006_2020", "geih_2021_present"]
+      "description_es": "Características de las personas que buscan empleo.",
+      "description_en": "Characteristics of unemployed job seekers.",
+      "available_in": [
+        "geih_2006_2020",
+        "geih_2021_present"
+      ]
     },
     "inactivos": {
       "level": "persona",
-      "description_es": "Personas fuera de la fuerza de trabajo: razones, actividades.",
-      "description_en": "Persons outside the labor force: reasons, activities.",
-      "available_in": ["geih_2006_2020", "geih_2021_present"]
+      "description_es": "Personas no ocupadas y no buscando empleo.",
+      "description_en": "Persons not employed and not seeking work.",
+      "available_in": [
+        "geih_2006_2020",
+        "geih_2021_present"
+      ]
     },
     "vivienda_hogares": {
       "level": "hogar",
       "description_es": "Características de la vivienda y los hogares que la habitan: servicios, tenencia, materiales.",
       "description_en": "Dwelling and household characteristics: services, tenure, materials.",
-      "available_in": ["geih_2006_2020", "geih_2021_present"]
+      "available_in": [
+        "geih_2006_2020",
+        "geih_2021_present"
+      ]
     },
     "otros_ingresos": {
       "level": "persona",
-      "description_es": "Ingresos no laborales: arriendos, pensiones, transferencias, intereses.",
-      "description_en": "Non-labor income: rents, pensions, transfers, interest.",
-      "available_in": ["geih_2006_2020", "geih_2021_present"]
+      "description_es": "Ingresos no laborales: pensiones, transferencias, ayudas, intereses, etc.",
+      "description_en": "Non-labor income: pensions, transfers, aid, interests, etc.",
+      "available_in": [
+        "geih_2006_2020",
+        "geih_2021_present"
+      ]
     },
     "migracion": {
       "level": "persona",
-      "description_es": "Historial migratorio de las personas: lugar de nacimiento, residencia anterior, motivos de migración. Módulo introducido en GEIH-2 (2021).",
-      "description_en": "Migration history: birthplace, previous residence, migration reasons. Module introduced in GEIH-2 (2021).",
-      "available_in": ["geih_2021_present"]
+      "description_es": "Información sobre migración y desplazamientos de las personas.",
+      "description_en": "Migration and displacement information for persons.",
+      "available_in": [
+        "geih_2021_present"
+      ]
     },
     "otras_formas_trabajo": {
       "level": "persona",
-      "description_es": "Trabajo informal, autoempleo, trabajo de subsistencia y otras formas no clasificadas como ocupación principal. Módulo introducido en GEIH-2 (2021) para captar formas alternativas de trabajo recomendadas por la 19ª CIET de la OIT.",
-      "description_en": "Informal, self-employment, subsistence work and other forms not classified as main occupation. Module introduced in GEIH-2 (2021) to capture alternative work forms recommended by the ILO 19th ICLS.",
-      "available_in": ["geih_2021_present"]
+      "description_es": "Trabajo voluntario, doméstico no remunerado, y otras actividades laborales fuera del empleo formal.",
+      "description_en": "Volunteer work, unpaid domestic labor, and other labor activities outside formal employment.",
+      "available_in": [
+        "geih_2021_present"
+      ]
     }
   },
   "data": {
+    "2007-01": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/13491",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 6857687,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2007-02": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/13493",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7570718,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2007-03": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/13495",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7654604,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2007-04": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/13497",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7717519,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2007-05": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/13499",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7560232,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2007-06": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/13501",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7465861,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2007-07": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/13503",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7518289,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2007-08": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/13505",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7623147,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2007-09": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/10924",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7497318,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2007-10": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/10928",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7413432,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2007-11": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/10930",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 7014973,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2007-12": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/10934",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
+      "checksum_sha256": null,
+      "size_bytes": 6406799,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2008-01": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/3268",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 14921236,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2008-02": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/3269",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 15382609,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2008-03": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/3270",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 15015608,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2008-04": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12794",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 7361003,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2008-05": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12795",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 7172259,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2008-06": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12796",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 6784286,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2008-07": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12798",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 6815744,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2008-08": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12799",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 6878658,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2008-09": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12800",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 6700400,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2008-10": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12801",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 6910115,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2008-11": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12802",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 6815744,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2008-12": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/206/download/12803",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/206",
+      "checksum_sha256": null,
+      "size_bytes": 6438256,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2009-01": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/12995",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6207569,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2009-02": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/12996",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6469713,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2009-03": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/12997",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6427770,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2009-04": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/12998",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6616514,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2009-05": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/12999",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6553600,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2009-06": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/13000",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6448742,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2009-07": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/13001",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6763315,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2009-08": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/13002",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6784286,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2009-09": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/13003",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6763315,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2009-10": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/13004",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6742343,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2009-11": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/13005",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6700400,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2009-12": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/207/download/13006",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/207",
+      "checksum_sha256": null,
+      "size_bytes": 6448742,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2010-01": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12974",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 6721372,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2010-02": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12975",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 6920601,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2010-03": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12976",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 6763315,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2010-04": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12977",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 7161774,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2010-05": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12978",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 6962544,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2010-06": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12979",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 6857687,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2010-07": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12980",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 6994001,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2010-08": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12981",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 7172259,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2010-09": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12982",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 7140802,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2010-10": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12983",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 7098859,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2010-11": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12984",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 7109345,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2010-12": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/205/download/12985",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/205",
+      "checksum_sha256": null,
+      "size_bytes": 6805258,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2011-01": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12719",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 6847201,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2011-02": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12720",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7528775,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2011-03": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12721",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7277117,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2011-04": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12722",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 6910115,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2011-05": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12723",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7245660,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2011-06": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12724",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7235174,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2011-07": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12725",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7266631,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2011-08": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12726",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7214202,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2011-09": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12727",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7182745,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2011-10": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12728",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7140802,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2011-11": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12729",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 7214202,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2011-12": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/182/download/12730",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/182",
+      "checksum_sha256": null,
+      "size_bytes": 6962544,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2012-01": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13013",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 6847201,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2012-02": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13014",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7193231,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2012-03": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13015",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7130316,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2012-04": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13016",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7214202,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2012-05": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13017",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7476346,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2012-06": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13018",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7109345,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2012-07": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13019",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7067402,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2012-08": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13020",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7203717,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2012-09": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13021",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7109345,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2012-10": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13022",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7172259,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2012-11": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13023",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 7235174,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2012-12": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/77/download/13024",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/77",
+      "checksum_sha256": null,
+      "size_bytes": 6637486,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2013-01": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13027",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 7004487,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2013-02": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13028",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 7004487,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2013-03": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13029",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6889144,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2013-04": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13030",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6973030,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2013-05": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13031",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 7109345,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2013-06": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13032",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6962544,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2013-07": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13033",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6836715,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2013-08": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13034",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6899630,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2013-09": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13035",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6794772,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2013-10": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13036",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6952058,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2013-11": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13037",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6836715,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2013-12": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/68/download/13038",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/68",
+      "checksum_sha256": null,
+      "size_bytes": 6427770,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2014-01": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13043",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6752829,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2014-02": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13044",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6826229,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2014-03": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13045",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6679429,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2014-04": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13046",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6658457,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2014-05": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13047",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6931087,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2014-06": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13048",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6532628,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2014-07": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13049",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6710886,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2014-08": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13050",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6815744,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2014-09": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13051",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6658457,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2014-10": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13052",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 7014973,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2014-11": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13053",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6700400,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2014-12": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/328/download/13054",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/328",
+      "checksum_sha256": null,
+      "size_bytes": 6417285,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2015-01": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13056",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6585057,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2015-02": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13057",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6710886,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2015-03": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13058",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6689914,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2015-04": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13059",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6910115,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2015-05": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13060",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6763315,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2015-06": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13061",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6668943,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2015-07": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13062",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6899630,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2015-08": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13063",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6910115,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2015-09": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13064",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6857687,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2015-10": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13065",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6962544,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2015-11": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13066",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6847201,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2015-12": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13067",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
+      "checksum_sha256": null,
+      "size_bytes": 6616514,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2016-01": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13101",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 6616514,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2016-02": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13102",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 6647971,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2016-03": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13103",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 7130316,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2016-04": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13104",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 6773800,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2016-05": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13105",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 7014973,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2016-06": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13106",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 7046430,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2016-07": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13107",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 7014973,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2016-08": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13108",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 6962544,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2016-09": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13109",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 6721372,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2016-10": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13110",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 6606028,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2016-11": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13111",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 6574571,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2016-12": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/427/download/13112",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/427",
+      "checksum_sha256": null,
+      "size_bytes": 6364856,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2017-01": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/13294",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 6417285,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2017-02": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/13295",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 6553600,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2017-03": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/13296",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 6490685,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2017-04": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/13297",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 6469713,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2017-05": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/13298",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 6679429,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2017-06": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/13299",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 6553600,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2017-07": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/13300",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 6952058,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2017-08": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/13301",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 7035944,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2017-09": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/9035",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 9133096,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2017-10": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/9038",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 9133096,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2017-11": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/9342",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 9017753,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2017-12": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/458/download/9282",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/458",
+      "checksum_sha256": null,
+      "size_bytes": 8535408,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2018-01": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/12198",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6606028,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2018-02": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/12201",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6794772,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2018-03": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/12204",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6826229,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2018-04": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/12207",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6952058,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2018-05": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/12210",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 7119831,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2018-06": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/9909",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6647971,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2018-07": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/10017",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6878658,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2018-08": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/10102",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 7035944,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2018-09": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/10115",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6773800,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2018-10": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/10205",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6742343,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2018-11": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/10341",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6794772,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2018-12": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/547/download/10443",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/547",
+      "checksum_sha256": null,
+      "size_bytes": 6553600,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2019-01": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/10719",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6784286,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2019-02": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/10964",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6910115,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2019-03": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/11117",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6710886,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2019-04": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/11184",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6794772,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2019-05": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/11300",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 7025459,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2019-06": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/12068",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6689914,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2019-07": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/12100",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6815744,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2019-08": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/12221",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6931087,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2019-09": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/12275",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6721372,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2019-10": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/12365",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6805258,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2019-11": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/12444",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6668943,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2019-12": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/599/download/12516",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/599",
+      "checksum_sha256": null,
+      "size_bytes": 6417285,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2020-01": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22286",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 21799895,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2020-02": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22287",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 21852323,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2020-03": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22288",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 10915676,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2020-04": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22289",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 8399093,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2020-05": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22290",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 12289310,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2020-06": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22291",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 12278824,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2020-07": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22292",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 12142510,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2020-08": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22293",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 24043847,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2020-09": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22294",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 23708303,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2020-10": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22295",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 24201134,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2020-11": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22296",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 23435673,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2020-12": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/780/download/22297",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/780",
+      "checksum_sha256": null,
+      "size_bytes": 23330816,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2021-01": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/23451",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 5463080,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2021-02": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/23454",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 5494538,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2021-03": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/23457",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 5400166,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2021-04": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/23460",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 5546967,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2021-05": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20528",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 6627000,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2021-06": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20551",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 6176112,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2021-07": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20630",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 6910115,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2021-08": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20673",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 6574571,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2021-09": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20676",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 6490685,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2021-10": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20707",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 6291456,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2021-11": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20833",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 5987368,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2021-12": {
+      "epoch": "geih_2006_2020",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20902",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
+      "checksum_sha256": null,
+      "size_bytes": 5924454,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "cabecera": "Cabecera - Características generales (Personas).csv",
+          "resto": "Resto - Características generales (Personas).csv"
+        },
+        "ocupados": {
+          "cabecera": "Cabecera - Ocupados.csv",
+          "resto": "Resto - Ocupados.csv"
+        },
+        "desocupados": {
+          "cabecera": "Cabecera - Desocupados.csv",
+          "resto": "Resto - Desocupados.csv"
+        },
+        "inactivos": {
+          "cabecera": "Cabecera - Inactivos.csv",
+          "resto": "Resto - Inactivos.csv"
+        },
+        "vivienda_hogares": {
+          "cabecera": "Cabecera - Vivienda y Hogares.csv",
+          "resto": "Resto - Vivienda y Hogares.csv"
+        },
+        "otros_ingresos": {
+          "cabecera": "Cabecera - Otros ingresos.csv",
+          "resto": "Resto - Otros ingresos.csv"
+        }
+      },
+      "notes": null
+    },
+    "2022-01": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22688",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 76986449,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2022-02": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22689",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 78538342,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2022-03": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22690",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 79104573,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2022-04": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22894",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 78066483,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2022-05": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22692",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 48706355,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2022-06": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22693",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 70590136,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2022-07": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22694",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 68241326,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2022-08": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22695",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 70663536,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2022-09": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22696",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 75990302,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2022-10": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22697",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 71638712,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2022-11": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/23016",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 72666316,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2022-12": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22699",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
+      "checksum_sha256": null,
+      "size_bytes": 66521661,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2023-01": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/22349",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 69122129,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2023-02": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/22466",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 71963770,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2023-03": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/22553",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 74323066,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2023-04": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/22610",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 63847792,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2023-05": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/22819",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 67979182,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2023-06": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/22888",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 68199383,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2023-07": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/22917",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 67318579,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2023-08": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/22946",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 70999080,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2023-09": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/23017",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 64592281,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2023-10": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/23081",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 61404610,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2023-11": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/23115",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 69981962,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2023-12": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/782/download/23243",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/782",
+      "checksum_sha256": null,
+      "size_bytes": 70474792,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2024-01": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23313",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 68440555,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2024-02": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23362",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 68178411,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2024-03": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23596",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 67171778,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2024-04": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23496",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 67821895,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2024-05": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23598",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 68555898,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
     "2024-06": {
       "epoch": "geih_2021_present",
       "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23625",
@@ -94,6 +8061,766 @@
         }
       },
       "notes": "Phase 1 first validated entry. desocupados and inactivos both map to 'No ocupados.CSV' without row_filter; the column distinguishing them is to be confirmed in Phase 2 (likely OCI). Until row_filter is added, loading desocupados or inactivos returns the full no-ocupados population."
+    },
+    "2024-07": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23631",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 69090672,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2024-08": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23651",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 62757273,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2024-09": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23671",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 59905146,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2024-10": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23677",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 60125347,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2024-11": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23729",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 59317944,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2024-12": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/819/download/23794",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/819",
+      "checksum_sha256": null,
+      "size_bytes": 57388564,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2025-01": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24263",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 61865984,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2025-02": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24264",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 63732449,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2025-03": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24267",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 65148026,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2025-04": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24269",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 64833454,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2025-05": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24268",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 66532147,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2025-06": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24266",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 63994593,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2025-07": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24265",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 64099450,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2025-08": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24307",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 64393052,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2025-09": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24324",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 65263370,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2025-10": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24382",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 69247959,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2025-11": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24406",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 66972549,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2025-12": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/853/download/24463",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/853",
+      "checksum_sha256": null,
+      "size_bytes": 63428362,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2026-01": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/900/download/24530",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/900",
+      "checksum_sha256": null,
+      "size_bytes": 65567457,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
+    },
+    "2026-02": {
+      "epoch": "geih_2021_present",
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/900/download/24594",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/900",
+      "checksum_sha256": null,
+      "size_bytes": 70632079,
+      "scraped_at": "2026-05-01T06:49:28.328748+00:00",
+      "validated": false,
+      "validated_by": null,
+      "validated_at": null,
+      "modules": {
+        "caracteristicas_generales": {
+          "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+        },
+        "ocupados": {
+          "file": "CSV/Ocupados.CSV"
+        },
+        "desocupados": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "inactivos": {
+          "file": "CSV/No ocupados.CSV"
+        },
+        "vivienda_hogares": {
+          "file": "CSV/Datos del hogar y la vivienda.CSV"
+        },
+        "otros_ingresos": {
+          "file": "CSV/Otros ingresos e impuestos.CSV"
+        },
+        "migracion": {
+          "file": "CSV/Migración.CSV"
+        },
+        "otras_formas_trabajo": {
+          "file": "CSV/Otras formas de trabajo.CSV"
+        }
+      },
+      "notes": null
     }
   }
 }

--- a/scripts/generate_sources_from_catalog.py
+++ b/scripts/generate_sources_from_catalog.py
@@ -1,0 +1,273 @@
+"""Generate pulso/data/sources.json from pulso/data/_scraped_catalog.json.
+
+Produces a deterministic sources.json with one MonthRecord per catalog entry.
+Manually validated entries (e.g. 2024-06) are preserved unchanged.
+
+Usage:
+    python scripts/generate_sources_from_catalog.py \
+        --catalog pulso/data/_scraped_catalog.json \
+        --output pulso/data/sources.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import jsonschema
+
+# ---------------------------------------------------------------------------
+# Canonical module definitions
+# ---------------------------------------------------------------------------
+
+CANONICAL_MODULES: dict[str, dict] = {
+    "caracteristicas_generales": {
+        "level": "persona",
+        "description_es": "Características demográficas, educativas y de salud de las personas.",
+        "description_en": "Demographic, educational, and health characteristics of persons.",
+        "available_in": ["geih_2006_2020", "geih_2021_present"],
+    },
+    "ocupados": {
+        "level": "persona",
+        "description_es": "Información laboral de las personas ocupadas en la semana de referencia.",
+        "description_en": "Labor market information for employed persons in the reference week.",
+        "available_in": ["geih_2006_2020", "geih_2021_present"],
+    },
+    "desocupados": {
+        "level": "persona",
+        "description_es": "Características de las personas que buscan empleo.",
+        "description_en": "Characteristics of unemployed job seekers.",
+        "available_in": ["geih_2006_2020", "geih_2021_present"],
+    },
+    "inactivos": {
+        "level": "persona",
+        "description_es": "Personas no ocupadas y no buscando empleo.",
+        "description_en": "Persons not employed and not seeking work.",
+        "available_in": ["geih_2006_2020", "geih_2021_present"],
+    },
+    "vivienda_hogares": {
+        "level": "hogar",
+        "description_es": "Características de la vivienda y los hogares que la habitan: servicios, tenencia, materiales.",
+        "description_en": "Dwelling and household characteristics: services, tenure, materials.",
+        "available_in": ["geih_2006_2020", "geih_2021_present"],
+    },
+    "otros_ingresos": {
+        "level": "persona",
+        "description_es": "Ingresos no laborales: pensiones, transferencias, ayudas, intereses, etc.",
+        "description_en": "Non-labor income: pensions, transfers, aid, interests, etc.",
+        "available_in": ["geih_2006_2020", "geih_2021_present"],
+    },
+    "migracion": {
+        "level": "persona",
+        "description_es": "Información sobre migración y desplazamientos de las personas.",
+        "description_en": "Migration and displacement information for persons.",
+        "available_in": ["geih_2021_present"],
+    },
+    "otras_formas_trabajo": {
+        "level": "persona",
+        "description_es": "Trabajo voluntario, doméstico no remunerado, y otras actividades laborales fuera del empleo formal.",
+        "description_en": "Volunteer work, unpaid domestic labor, and other labor activities outside formal employment.",
+        "available_in": ["geih_2021_present"],
+    },
+}
+
+# ---------------------------------------------------------------------------
+# File path templates per shape
+# ---------------------------------------------------------------------------
+
+# Shape B (Unified, geih_2021_present): canonical filenames verified against 2024-06 ZIP.
+# desocupados/inactivos share "No ocupados.CSV" without row_filter — Phase 3.4 confirms
+# the OCI column semantics and will add row_filter if needed.
+SHAPE_B_FILES: dict[str, dict] = {
+    "caracteristicas_generales": {
+        "file": "CSV/Características generales, seguridad social en salud y educación.CSV"
+    },
+    "ocupados": {"file": "CSV/Ocupados.CSV"},
+    "desocupados": {"file": "CSV/No ocupados.CSV"},
+    "inactivos": {"file": "CSV/No ocupados.CSV"},
+    "vivienda_hogares": {"file": "CSV/Datos del hogar y la vivienda.CSV"},
+    "otros_ingresos": {"file": "CSV/Otros ingresos e impuestos.CSV"},
+    "migracion": {"file": "CSV/Migración.CSV"},
+    "otras_formas_trabajo": {"file": "CSV/Otras formas de trabajo.CSV"},
+}
+
+# Shape A (Split, geih_2006_2020): canonical filenames.
+# The Shape A parser (is_shape_a + find_shape_a_files) tolerates real-world
+# variations (missing accents, 2007 typos like "Caractericas", spacing) via
+# keyword matching — so these canonical names are the authoritative declarations,
+# not the actual filenames on disk.
+SHAPE_A_FILES: dict[str, dict] = {
+    "caracteristicas_generales": {
+        "cabecera": "Cabecera - Características generales (Personas).csv",
+        "resto": "Resto - Características generales (Personas).csv",
+    },
+    "ocupados": {
+        "cabecera": "Cabecera - Ocupados.csv",
+        "resto": "Resto - Ocupados.csv",
+    },
+    "desocupados": {
+        "cabecera": "Cabecera - Desocupados.csv",
+        "resto": "Resto - Desocupados.csv",
+    },
+    "inactivos": {
+        "cabecera": "Cabecera - Inactivos.csv",
+        "resto": "Resto - Inactivos.csv",
+    },
+    "vivienda_hogares": {
+        "cabecera": "Cabecera - Vivienda y Hogares.csv",
+        "resto": "Resto - Vivienda y Hogares.csv",
+    },
+    "otros_ingresos": {
+        "cabecera": "Cabecera - Otros ingresos.csv",
+        "resto": "Resto - Otros ingresos.csv",
+    },
+    # migracion and otras_formas_trabajo: not available in geih_2006_2020.
+}
+
+
+# ---------------------------------------------------------------------------
+# Core helpers
+# ---------------------------------------------------------------------------
+
+
+def build_month_record(entry: dict, catalog_scraped_at: str) -> dict:
+    """Build a MonthRecord dict from a _scraped_catalog.json entry."""
+    epoch = entry["epoch_inferred"]
+
+    if epoch == "geih_2021_present":
+        modules = {
+            name: dict(SHAPE_B_FILES[name])
+            for name in CANONICAL_MODULES
+            if epoch in CANONICAL_MODULES[name]["available_in"]
+        }
+    else:
+        # geih_2006_2020: only modules with available_in that includes this epoch
+        # AND that have a Shape A file definition.
+        modules = {
+            name: dict(SHAPE_A_FILES[name])
+            for name in CANONICAL_MODULES
+            if epoch in CANONICAL_MODULES[name]["available_in"]
+            and name in SHAPE_A_FILES
+        }
+
+    return {
+        "epoch": epoch,
+        "download_url": entry["download_url"],
+        "landing_page": entry.get("landing_page"),
+        "checksum_sha256": entry.get("checksum_sha256"),  # null for most entries
+        "size_bytes": entry.get("size_bytes"),
+        "scraped_at": catalog_scraped_at,
+        "validated": False,
+        "validated_by": None,
+        "validated_at": None,
+        "modules": modules,
+        "notes": None,
+    }
+
+
+def load_existing_sources(path: Path) -> dict | None:
+    if path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--catalog",
+        type=Path,
+        default=Path("pulso/data/_scraped_catalog.json"),
+        help="Path to _scraped_catalog.json",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("pulso/data/sources.json"),
+        help="Path to write sources.json",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate but do not write the output file",
+    )
+    args = parser.parse_args()
+
+    # Load catalog
+    catalog = json.loads(args.catalog.read_text(encoding="utf-8"))
+    entries = catalog["entries"]
+    catalog_scraped_at = catalog["scraped_at"]
+    print(f"Loaded {len(entries)} entries from catalog")
+
+    # Load existing sources (to preserve manually validated entries)
+    existing = load_existing_sources(args.output)
+    existing_data: dict = existing.get("data", {}) if existing else {}
+
+    # Build data dict
+    new_data: dict = {}
+    preserved = 0
+    generated = 0
+
+    for entry in entries:
+        key = f"{entry['year']}-{entry['month']:02d}"
+
+        if key in existing_data and existing_data[key].get("validated"):
+            new_data[key] = existing_data[key]
+            preserved += 1
+        else:
+            new_data[key] = build_month_record(entry, catalog_scraped_at)
+            generated += 1
+
+    print(f"Preserved {preserved} manually validated entr{'y' if preserved == 1 else 'ies'}: "
+          f"{', '.join(k for k, v in existing_data.items() if v.get('validated'))}")
+    print(f"Generated {generated} new entries")
+
+    # Build full sources structure
+    result = {
+        "metadata": {
+            "schema_version": "1.1.0",
+            "data_version": "2026.04",
+            "last_updated": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "scraper_version": "generate_sources_from_catalog/0.1.0",
+            "covered_range": [
+                sorted(new_data.keys())[0],
+                sorted(new_data.keys())[-1],
+            ],
+        },
+        "modules": CANONICAL_MODULES,
+        "data": new_data,
+    }
+
+    # Validate against schema
+    schema_path = args.output.parent / "schemas" / "sources.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    try:
+        jsonschema.validate(instance=result, schema=schema)
+        print("Schema validation: OK")
+    except jsonschema.ValidationError as e:
+        print(f"VALIDATION FAILED: {e.message}")
+        path_str = " -> ".join(str(p) for p in e.absolute_path)
+        print(f"Path: {path_str}")
+        return 1
+
+    if args.dry_run:
+        print(f"DRY RUN — would write {len(new_data)} entries to {args.output}")
+        return 0
+
+    args.output.write_text(
+        json.dumps(result, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Written {len(new_data)} entries to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_sources_from_catalog.py
+++ b/scripts/generate_sources_from_catalog.py
@@ -149,8 +149,7 @@ def build_month_record(entry: dict, catalog_scraped_at: str) -> dict:
         modules = {
             name: dict(SHAPE_A_FILES[name])
             for name in CANONICAL_MODULES
-            if epoch in CANONICAL_MODULES[name]["available_in"]
-            and name in SHAPE_A_FILES
+            if epoch in CANONICAL_MODULES[name]["available_in"] and name in SHAPE_A_FILES
         }
 
     return {
@@ -225,8 +224,10 @@ def main() -> int:
             new_data[key] = build_month_record(entry, catalog_scraped_at)
             generated += 1
 
-    print(f"Preserved {preserved} manually validated entr{'y' if preserved == 1 else 'ies'}: "
-          f"{', '.join(k for k, v in existing_data.items() if v.get('validated'))}")
+    print(
+        f"Preserved {preserved} manually validated entr{'y' if preserved == 1 else 'ies'}: "
+        f"{', '.join(k for k, v in existing_data.items() if v.get('validated'))}"
+    )
     print(f"Generated {generated} new entries")
 
     # Build full sources structure


### PR DESCRIPTION
## Summary

Phase 3.2.C — final sub-sprint of Phase 3.2. Scales `pulso/data/sources.json` from 1 entry (2024-06 manual) to 230 entries covering January 2007 through February 2026.

## Changes

- **`pulso/data/schemas/sources.schema.json`**: `checksum_sha256` made nullable. DANE does not publish checksums; Phase 3.4 will fill them after downloading each ZIP.
- **`scripts/generate_sources_from_catalog.py`**: deterministic generator from `_scraped_catalog.json`. Idempotent; re-run produces the same output.
- **`pulso/data/sources.json`**: 1 → 230 entries (180 Shape A + 50 Shape B)
- **`docs/PHASE_3_DATA_NOTES.md`**: documents all decisions

## Verification

```
python scripts/validate_sources.py
✅ epochs.json validates against epochs.schema.json
✅ sources.json validates against sources.schema.json
✅ variable_map.json validates against variable_map.schema.json

Total entries: 230
Shape A (geih_2006_2020): 180
Shape B (geih_2021_present): 50

2024-06 validated: True
2024-06 checksum: c5799177604b0e08...  (preserved)

156 tests pass, 18 skipped (no new tests this sprint)
Phase 2 regression: load_merged(2024, 6) → (70020, 525) ✅
```

## Key decisions

- **Canonical filenames declared, not actual disk names**: Shape A parser tolerates real-world variations (typos, missing accents, spacing) via keyword matching — sources.json has authoritative spellings.
- **2024-06 preserved**: validated entry from Phase 1 unchanged.
- **Shape A entries: 6 modules** (no migracion/otras_formas_trabajo per available_in).
- **row_filter omitted**: desocupados/inactivos share "No ocupados.CSV" — Phase 3.4 confirms OCI semantics.

## Closes #27