### PR TITLE
chore(dev): add pre-commit hook with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+﻿# .pre-commit-config.yaml
+# Pre-commit hooks for pulso. Auto-formats and lints code on every commit.
+# Setup: pip install pre-commit && pre-commit install
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format


### PR DESCRIPTION
Adds .pre-commit-config.yaml with ruff format and ruff check --fix.

## Why
Across 5 PRs (Phase 2 + Phase 3.1 + 3.2.B + 3.2.C) we consistently saw ruff format failures in CI even though local pytest passed. Cause: commits skip ruff format step. Pre-commit hook fixes this once and forever.

## Setup
Any new contributor runs once after cloning:
  pip install pre-commit
  pre-commit install

From that point, every commit auto-runs ruff format and ruff check --fix.

## CI impact
None. Pre-commit runs locally before push. CI workflows already check ruff so this is defense-in-depth.

## Verification
- Hook installed locally, dry-run on commit succeeded
- Branch path conventions check should pass (uses feat/code prefix)