### PR TITLE
fix(parser): use word-boundary regex in find_shape_a_files (Phase 3.3.1)

### DIFF
--- a/pulso/_core/parser.py
+++ b/pulso/_core/parser.py
@@ -14,6 +14,7 @@ Shape A auto-discovery (Phase 3.2.B):
 
 from __future__ import annotations
 
+import re
 import zipfile
 from typing import TYPE_CHECKING, Literal, cast
 
@@ -90,8 +91,9 @@ def find_shape_a_files(
         else:
             continue
 
-        # Match at least one keyword
-        if not any(kw.lower() in lower for kw in keywords):
+        # Match at least one keyword using word-boundary regex so that e.g.
+        # "ocupados" does NOT match inside "desocupados".
+        if not any(re.search(r"\b" + re.escape(kw.lower()) + r"\b", lower) for kw in keywords):
             continue
 
         if prefix == "cabecera":

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -399,3 +399,60 @@ def test_parse_shape_a_raises_when_module_missing(tmp_path: Path, shape_a_epoch:
 
     with pytest.raises(ParseError, match="vivienda_hogares"):
         parse_shape_a_module(zip_path, "vivienda_hogares", shape_a_epoch)
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: word-boundary keyword matching (Phase 3.3.1 hotfix)
+# ---------------------------------------------------------------------------
+
+
+def test_find_shape_a_files_distinguishes_ocupados_from_desocupados(tmp_path: Path) -> None:
+    """Regression: 'ocupados' must NOT match 'Desocupados' as a substring.
+
+    Before this fix, searching for module 'ocupados' would match
+    'Cabecera - Desocupados.csv' because 'ocupados' is a substring of 'desocupados'.
+    """
+    from pulso._core.parser import find_shape_a_files
+
+    zip_path = tmp_path / "test.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("CSV/Cabecera - Desocupados.csv", "x")
+        zf.writestr("CSV/Resto - Desocupados.csv", "x")
+
+    cab, resto = find_shape_a_files(zip_path, "ocupados")
+    assert cab is None, f"Expected no match for 'ocupados', got: {cab}"
+    assert resto is None, f"Expected no match for 'ocupados', got: {resto}"
+
+
+def test_find_shape_a_files_robust_to_filename_order(tmp_path: Path) -> None:
+    """Regression: file order in the ZIP must not affect keyword-match correctness.
+
+    Before this fix, fixtures relied on alphabetical ordering (D < O) so that
+    'Ocupados' would overwrite 'Desocupados' as the last match. Real DANE ZIPs
+    do not guarantee any file order, so the fix must work regardless of order.
+    """
+    from pulso._core.parser import find_shape_a_files
+
+    zip_path = tmp_path / "test.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        # Desocupados written FIRST (non-alphabetical: if old code iterated this
+        # order and Ocupados came after, Ocupados would win by last-match — but
+        # in real ZIPs the order could be reversed, so the fix must not rely on it)
+        zf.writestr("CSV/Cabecera - Desocupados.csv", "x")
+        zf.writestr("CSV/Resto - Desocupados.csv", "x")
+        zf.writestr("CSV/Cabecera - Ocupados.csv", "x")
+        zf.writestr("CSV/Resto - Ocupados.csv", "x")
+
+    cab_o, resto_o = find_shape_a_files(zip_path, "ocupados")
+    assert cab_o is not None, "Expected to find Cabecera - Ocupados"
+    assert "Ocupados" in cab_o, f"Wrong file matched: {cab_o}"
+    assert "Desocupados" not in cab_o, f"Matched Desocupados instead of Ocupados: {cab_o}"
+    assert resto_o is not None
+    assert "Ocupados" in resto_o, f"Wrong file: {resto_o}"
+    assert "Desocupados" not in resto_o, f"Matched Desocupados instead of Ocupados: {resto_o}"
+
+    cab_d, resto_d = find_shape_a_files(zip_path, "desocupados")
+    assert cab_d is not None
+    assert "Desocupados" in cab_d, f"Wrong file matched: {cab_d}"
+    assert resto_d is not None
+    assert "Desocupados" in resto_d, f"Wrong file: {resto_d}"


### PR DESCRIPTION
Hotfix discovered during Phase 3.3 mass validation.

## Problem

`find_shape_a_files()` used substring matching:

```python
if not any(kw.lower() in lower for kw in keywords):
    continue
```

This caused `"ocupados"` to match `"Desocupados"` filenames since `"ocupados"` is a substring of `"desocupados"`. With last-match-wins iteration, whichever file appeared last in the ZIP's namelist would win — making correctness depend on ZIP creation order, which DANE does not guarantee.

## Fix

Word-boundary regex matching in `pulso/_core/parser.py`:

```python
if not any(
    re.search(r"\b" + re.escape(kw.lower()) + r"\b", lower) for kw in keywords
):
    continue
```

`\b` ensures `"ocupados"` matches only as a whole word, not as a suffix inside `"desocupados"`.

## Tests

Two regression tests added to `tests/unit/test_parser.py`:

- `test_find_shape_a_files_distinguishes_ocupados_from_desocupados`: asserts that a ZIP containing only `Desocupados` files returns `(None, None)` when searching for `ocupados`.
- `test_find_shape_a_files_robust_to_filename_order`: writes `Desocupados` before `Ocupados` in the ZIP (reverse alphabetical) and asserts each module resolves to the correct file.

## Counts

- Before: 412 tests
- After: 414 tests (412 + 2 new regression tests)
- Phase 2 regression: `load_merged(2024, 6).shape == (70020, 525)` ✓

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)