### PR TITLE
data(sources): real SHA256 checksums for 5 strategic months

### DIFF
--- a/pulso/data/sources.json
+++ b/pulso/data/sources.json
@@ -504,12 +504,12 @@
       "epoch": "geih_2006_2020",
       "download_url": "https://microdatos.dane.gov.co/index.php/catalog/317/download/10934",
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/317",
-      "checksum_sha256": null,
+      "checksum_sha256": "ec339fca43a262fb3e15d586094f3d4c28af0a24048d0e2e9adf7560c84b4d4a",
       "size_bytes": 6406799,
       "scraped_at": "2026-05-01T06:49:28.328748+00:00",
-      "validated": false,
-      "validated_by": null,
-      "validated_at": null,
+      "validated": true,
+      "validated_by": "automated",
+      "validated_at": "2026-05-02T02:49:04.926320+00:00",
       "modules": {
         "caracteristicas_generales": {
           "cabecera": "Cabecera - Características generales (Personas).csv",
@@ -3924,12 +3924,12 @@
       "epoch": "geih_2006_2020",
       "download_url": "https://microdatos.dane.gov.co/index.php/catalog/356/download/13061",
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/356",
-      "checksum_sha256": null,
+      "checksum_sha256": "361f8c4244be9785bbdef33eb5af51edcbb84d1980f0fa352b86a0f96429286a",
       "size_bytes": 6668943,
       "scraped_at": "2026-05-01T06:49:28.328748+00:00",
-      "validated": false,
-      "validated_by": null,
-      "validated_at": null,
+      "validated": true,
+      "validated_by": "automated",
+      "validated_at": "2026-05-02T02:49:04.935436+00:00",
       "modules": {
         "caracteristicas_generales": {
           "cabecera": "Cabecera - Características generales (Personas).csv",
@@ -6888,12 +6888,12 @@
       "epoch": "geih_2006_2020",
       "download_url": "https://microdatos.dane.gov.co/index.php/catalog/701/download/20902",
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/701",
-      "checksum_sha256": null,
+      "checksum_sha256": "607ece9b97744df908c60534ee2139f19042182906c8abe8f5eff53c4b8c9ace",
       "size_bytes": 5924454,
       "scraped_at": "2026-05-01T06:49:28.328748+00:00",
-      "validated": false,
-      "validated_by": null,
-      "validated_at": null,
+      "validated": true,
+      "validated_by": "automated",
+      "validated_at": "2026-05-02T02:49:04.944480+00:00",
       "modules": {
         "caracteristicas_generales": {
           "cabecera": "Cabecera - Características generales (Personas).csv",
@@ -6926,12 +6926,12 @@
       "epoch": "geih_2021_present",
       "download_url": "https://microdatos.dane.gov.co/index.php/catalog/771/download/22688",
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/771",
-      "checksum_sha256": null,
+      "checksum_sha256": "48d6bd634c3c98e48008cb08e9bd837694d91d00757fe6a965b928550af1c8aa",
       "size_bytes": 76986449,
       "scraped_at": "2026-05-01T06:49:28.328748+00:00",
-      "validated": false,
-      "validated_by": null,
-      "validated_at": null,
+      "validated": true,
+      "validated_by": "automated",
+      "validated_at": "2026-05-02T02:49:05.053204+00:00",
       "modules": {
         "caracteristicas_generales": {
           "file": "CSV/Características generales, seguridad social en salud y educación.CSV"


### PR DESCRIPTION
Companion data PR to #34. Updates 4 SHA256 checksums in sources.json from null to real computed values.

## Months affected

- 2007-12, 2015-06, 2021-12, 2022-01: checksum_sha256 changed from null to real SHA256, validated=true, validated_by="automated"
- 2024-06: unchanged (already had checksum from Phase 1 manual validation)

## Why split

Branch path conventions disallow modifying pulso/data/ from feat/code/* branches. Phase 3.4 PR (#34) only contained code/tests/docs.

## Verification

- python scripts/validate_sources.py: 3 ✅
- All entries still match the schema (4 nulls → 4 hex strings)
- Phase 2 regression intact: load_merged(2024, 6) shape (70020, 525)