### PR TITLE
feat(data): add empalme_sources.json with 11 GEIH Empalme catalogs (closes #38)

### DIFF
--- a/pulso/data/empalme_sources.json
+++ b/pulso/data/empalme_sources.json
@@ -1,0 +1,131 @@
+{
+  "metadata": {
+    "schema_version": "1.0",
+    "data_version": "2020",
+    "description": "Annual GEIH Empalme microdata catalogs (2010-2020). Each download is one ZIP per year containing 12 monthly sub-ZIPs with Cabecera/Resto structure (geih_2006_2020 epoch). Download URLs verified via HTTP HEAD on 2026-05-01. 2020 catalog exists on DANE portal but the ZIP has not been published.",
+    "scraped_at": "2026-05-01T00:00:00Z"
+  },
+  "data": {
+    "2010": {
+      "catalog_id": 765,
+      "idno": "DANE-DIMPE-GEIH-EMPALME-2010",
+      "downloadable": true,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/765/download/22001",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/765",
+      "zip_filename": "GEIH_Empalme_2010.zip",
+      "size_bytes": 219702328,
+      "checksum_sha256": null,
+      "notes": null
+    },
+    "2011": {
+      "catalog_id": 755,
+      "idno": "DANE-DIMPE-GEIH-EMPALME-2011",
+      "downloadable": true,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/755/download/21719",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/755",
+      "zip_filename": "GEIH_Empalme_2011.zip",
+      "size_bytes": 224312554,
+      "checksum_sha256": null,
+      "notes": null
+    },
+    "2012": {
+      "catalog_id": 760,
+      "idno": "DANE-DIMPE-GEIH-EMPALME-2012",
+      "downloadable": true,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/760/download/21879",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/760",
+      "zip_filename": "GEIH_Empalme_2012.zip",
+      "size_bytes": 261280670,
+      "checksum_sha256": null,
+      "notes": null
+    },
+    "2013": {
+      "catalog_id": 761,
+      "idno": "DANE-DIMPE-GEIH-EMPALME-2013",
+      "downloadable": true,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/761/download/21903",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/761",
+      "zip_filename": "GEIH_Emplame_2013.zip",
+      "size_bytes": 252617638,
+      "checksum_sha256": null,
+      "notes": "DANE typo in ZIP filename: 'GEIH_Emplame_2013.zip' (missing 'p' in Empalme). This is the actual filename served by the server and must be preserved as-is."
+    },
+    "2014": {
+      "catalog_id": 756,
+      "idno": "DANE-DIMPE-GEIH-EMPALME-2014",
+      "downloadable": true,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/756/download/21743",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/756",
+      "zip_filename": "GEIH_Empalme_2014.zip",
+      "size_bytes": 258217796,
+      "checksum_sha256": null,
+      "notes": null
+    },
+    "2015": {
+      "catalog_id": 762,
+      "idno": "DANE-DIMPE-GEIH-EMPALME-2015",
+      "downloadable": true,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/762/download/21928",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/762",
+      "zip_filename": "GEIH_Empalme_2015.zip",
+      "size_bytes": 229540468,
+      "checksum_sha256": null,
+      "notes": null
+    },
+    "2016": {
+      "catalog_id": 757,
+      "idno": "DANE-DIMPE-GEIH-EMPALME-2016",
+      "downloadable": true,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/757/download/21776",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/757",
+      "zip_filename": "GEIH_Empalme_2016.zip",
+      "size_bytes": 230131436,
+      "checksum_sha256": null,
+      "notes": null
+    },
+    "2017": {
+      "catalog_id": 763,
+      "idno": "DANE-DIMPE-GEIH-EMPALME-2017",
+      "downloadable": true,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/763/download/21947",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/763",
+      "zip_filename": "GEIH_Empalme_2017.zip",
+      "size_bytes": 234080087,
+      "checksum_sha256": null,
+      "notes": null
+    },
+    "2018": {
+      "catalog_id": 758,
+      "idno": "DANE-DIMPE-GEIH-EMPALME-2018",
+      "downloadable": true,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/758/download/21795",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/758",
+      "zip_filename": "GEIH_Empalme_2018.zip",
+      "size_bytes": 234063925,
+      "checksum_sha256": null,
+      "notes": null
+    },
+    "2019": {
+      "catalog_id": 759,
+      "idno": "DANE-DIMPE-GEIH-EMPALME-2019",
+      "downloadable": true,
+      "download_url": "https://microdatos.dane.gov.co/index.php/catalog/759/download/21814",
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/759",
+      "zip_filename": "GEIH_Empalme_2019.zip",
+      "size_bytes": 231904344,
+      "checksum_sha256": null,
+      "notes": null
+    },
+    "2020": {
+      "catalog_id": 764,
+      "idno": "DANE-DIMPE-GEIH-EMPAL-2020",
+      "downloadable": false,
+      "download_url": null,
+      "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/764",
+      "zip_filename": null,
+      "size_bytes": null,
+      "checksum_sha256": null,
+      "notes": "ZIP not published by DANE as of 2026-05-01. Catalog record exists (created 2022-11-15) with 8 data file entries defined, but no download is attached. IDNO anomaly: 'DANE-DIMPE-GEIH-EMPAL-2020' (truncated — missing 'ME' vs. the 2010-2019 pattern DANE-DIMPE-GEIH-EMPALME-{year})."
+    }
+  }
+}

--- a/pulso/data/schemas/empalme_sources.schema.json
+++ b/pulso/data/schemas/empalme_sources.schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Stebandido77/pulso/blob/main/pulso/data/schemas/empalme_sources.schema.json",
+  "title": "GEIH Empalme Catalog",
+  "description": "Annual GEIH Empalme microdata catalogs (2010-2020). Each entry is one ZIP per year containing 12 monthly sub-ZIPs with Cabecera/Resto structure (geih_2006_2020 epoch). Keys are 4-digit year strings.",
+  "type": "object",
+  "required": ["metadata", "data"],
+  "additionalProperties": false,
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "required": ["schema_version", "data_version", "description"],
+      "additionalProperties": false,
+      "properties": {
+        "schema_version": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+$",
+          "description": "Schema version (major.minor)."
+        },
+        "data_version": {
+          "type": "string",
+          "pattern": "^\\d{4}$",
+          "description": "Latest year covered by this catalog."
+        },
+        "description": {
+          "type": "string"
+        },
+        "scraped_at": {
+          "anyOf": [
+            { "type": "string", "format": "date-time" },
+            { "type": "null" }
+          ],
+          "description": "ISO-8601 timestamp of when this catalog was last verified."
+        }
+      }
+    },
+    "data": {
+      "type": "object",
+      "description": "Annual Empalme entries keyed by 4-digit year string (2010-2020).",
+      "patternProperties": {
+        "^20(1[0-9]|20)$": { "$ref": "#/$defs/EmpalmeEntry" }
+      },
+      "additionalProperties": false,
+      "minProperties": 1
+    }
+  },
+  "$defs": {
+    "EmpalmeEntry": {
+      "type": "object",
+      "required": [
+        "catalog_id",
+        "idno",
+        "downloadable",
+        "download_url",
+        "landing_page",
+        "zip_filename",
+        "size_bytes",
+        "checksum_sha256",
+        "notes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "catalog_id": {
+          "type": "integer",
+          "description": "Numeric catalog ID in the DANE Microdatos portal."
+        },
+        "idno": {
+          "type": "string",
+          "description": "NADA-style IDNO string used by the DANE API (e.g. DANE-DIMPE-GEIH-EMPALME-2015)."
+        },
+        "downloadable": {
+          "type": "boolean",
+          "description": "True when the ZIP file has been published and is publicly accessible. False for years where DANE has created the catalog record but not yet uploaded the data (currently 2020)."
+        },
+        "download_url": {
+          "anyOf": [
+            { "type": "string", "format": "uri" },
+            { "type": "null" }
+          ],
+          "description": "Direct URL to the annual ZIP. Pattern: https://microdatos.dane.gov.co/index.php/catalog/{catalog_id}/download/{resource_id}. Null when downloadable=false."
+        },
+        "landing_page": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to the DANE catalog landing page for this year."
+        },
+        "zip_filename": {
+          "anyOf": [
+            { "type": "string", "minLength": 1 },
+            { "type": "null" }
+          ],
+          "description": "Filename served via Content-Disposition by the download URL. Null when downloadable=false. Note: 2013 has a DANE-side typo in the filename."
+        },
+        "size_bytes": {
+          "anyOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "null" }
+          ],
+          "description": "Content-Length in bytes confirmed via HTTP HEAD. Null when downloadable=false."
+        },
+        "checksum_sha256": {
+          "anyOf": [
+            { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+            { "type": "null" }
+          ],
+          "description": "SHA-256 hex digest of the downloaded ZIP. Null until computed."
+        },
+        "notes": {
+          "anyOf": [
+            { "type": "string" },
+            { "type": "null" }
+          ],
+          "description": "Free-form notes: filename typos, publication anomalies, IDNO irregularities, etc."
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/test_empalme_sources.py
+++ b/tests/unit/test_empalme_sources.py
@@ -1,0 +1,127 @@
+"""Unit tests for pulso/data/empalme_sources.json and its schema.
+
+Validates catalog coverage, IDNO patterns, the 2020 anomaly, and
+the 2013 filename typo.  The integration-marked test verifies that all
+active download URLs are still reachable via HTTP HEAD.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import jsonschema
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(scope="module")
+def empalme_data(data_dir: Path) -> dict:
+    with (data_dir / "empalme_sources.json").open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="module")
+def empalme_schema(schemas_dir: Path) -> dict:
+    with (schemas_dir / "empalme_sources.schema.json").open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_schema_validates_empalme_sources(empalme_data: dict, empalme_schema: dict) -> None:
+    """empalme_sources.json must validate against empalme_sources.schema.json."""
+    jsonschema.validate(instance=empalme_data, schema=empalme_schema)
+
+
+def test_all_11_years_present(empalme_data: dict) -> None:
+    """All years 2010-2020 must be present as keys under data."""
+    expected = {str(y) for y in range(2010, 2021)}
+    actual = set(empalme_data["data"].keys())
+    assert (
+        actual == expected
+    ), f"Missing years: {expected - actual}, unexpected: {actual - expected}"
+
+
+def test_idno_2020_anomaly(empalme_data: dict) -> None:
+    """2020 IDNO must be the truncated variant (missing 'ME')."""
+    assert empalme_data["data"]["2020"]["idno"] == "DANE-DIMPE-GEIH-EMPAL-2020"
+
+
+def test_idno_pattern_other_years(empalme_data: dict) -> None:
+    """2010-2019 IDNOs must follow DANE-DIMPE-GEIH-EMPALME-{year}."""
+    for year in range(2010, 2020):
+        entry = empalme_data["data"][str(year)]
+        expected = f"DANE-DIMPE-GEIH-EMPALME-{year}"
+        assert (
+            entry["idno"] == expected
+        ), f"Year {year}: expected {expected!r}, got {entry['idno']!r}"
+
+
+def test_2020_not_downloadable(empalme_data: dict) -> None:
+    """2020 must have downloadable=False, null download_url, and null zip_filename."""
+    entry = empalme_data["data"]["2020"]
+    assert entry["downloadable"] is False
+    assert entry["download_url"] is None
+    assert entry["zip_filename"] is None
+    assert entry["size_bytes"] is None
+
+
+def test_2010_to_2019_downloadable(empalme_data: dict) -> None:
+    """Entries 2010-2019 must all be downloadable with non-null URLs and sizes."""
+    for year in range(2010, 2020):
+        entry = empalme_data["data"][str(year)]
+        assert entry["downloadable"] is True, f"Year {year}: expected downloadable=True"
+        assert entry["download_url"] is not None, f"Year {year}: download_url must not be null"
+        assert entry["size_bytes"] is not None, f"Year {year}: size_bytes must not be null"
+        assert entry["size_bytes"] > 0, f"Year {year}: size_bytes must be positive"
+
+
+def test_download_url_pattern(empalme_data: dict) -> None:
+    """Active download URLs must follow the expected DANE catalog/download pattern."""
+    base = "https://microdatos.dane.gov.co/index.php/catalog/"
+    for year in range(2010, 2020):
+        url = empalme_data["data"][str(year)]["download_url"]
+        assert url.startswith(base), f"Year {year}: unexpected URL prefix: {url}"
+        assert "/download/" in url, f"Year {year}: URL missing /download/ segment: {url}"
+
+
+def test_2013_typo_documented(empalme_data: dict) -> None:
+    """2013 ZIP filename must preserve DANE's typo and document it in notes."""
+    entry = empalme_data["data"]["2013"]
+    assert (
+        entry["zip_filename"] == "GEIH_Emplame_2013.zip"
+    ), "2013 filename must keep DANE's typo ('Emplame' not 'Empalme')"
+    assert entry["notes"] is not None, "2013 notes must not be null"
+    assert "typo" in entry["notes"].lower(), "2013 notes must document the filename typo"
+
+
+def test_schema_version(empalme_data: dict) -> None:
+    """Schema version must start at 1.0."""
+    assert empalme_data["metadata"]["schema_version"] == "1.0"
+
+
+def test_catalog_ids_are_unique(empalme_data: dict) -> None:
+    """Each year must have a distinct catalog_id."""
+    ids = [entry["catalog_id"] for entry in empalme_data["data"].values()]
+    assert len(ids) == len(set(ids)), f"Duplicate catalog_ids: {ids}"
+
+
+@pytest.mark.integration
+def test_download_urls_resolvable(empalme_data: dict) -> None:
+    """All active download URLs must return HTTP 200 with Content-Length > 0."""
+    import urllib.request
+
+    for year in range(2010, 2020):
+        entry = empalme_data["data"][str(year)]
+        url = entry["download_url"]
+        req = urllib.request.Request(
+            url, method="HEAD", headers={"User-Agent": "pulso-curator/1.0"}
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            assert resp.status == 200, f"Year {year}: expected 200, got {resp.status} for {url}"
+            content_length = int(resp.headers.get("Content-Length", 0))
+            assert content_length == entry["size_bytes"], (
+                f"Year {year}: Content-Length {content_length} != "
+                f"recorded size_bytes {entry['size_bytes']}"
+            )

--- a/tests/unit/test_empalme_sources.py
+++ b/tests/unit/test_empalme_sources.py
@@ -38,9 +38,9 @@ def test_all_11_years_present(empalme_data: dict) -> None:
     """All years 2010-2020 must be present as keys under data."""
     expected = {str(y) for y in range(2010, 2021)}
     actual = set(empalme_data["data"].keys())
-    assert (
-        actual == expected
-    ), f"Missing years: {expected - actual}, unexpected: {actual - expected}"
+    assert actual == expected, (
+        f"Missing years: {expected - actual}, unexpected: {actual - expected}"
+    )
 
 
 def test_idno_2020_anomaly(empalme_data: dict) -> None:
@@ -53,9 +53,9 @@ def test_idno_pattern_other_years(empalme_data: dict) -> None:
     for year in range(2010, 2020):
         entry = empalme_data["data"][str(year)]
         expected = f"DANE-DIMPE-GEIH-EMPALME-{year}"
-        assert (
-            entry["idno"] == expected
-        ), f"Year {year}: expected {expected!r}, got {entry['idno']!r}"
+        assert entry["idno"] == expected, (
+            f"Year {year}: expected {expected!r}, got {entry['idno']!r}"
+        )
 
 
 def test_2020_not_downloadable(empalme_data: dict) -> None:
@@ -89,9 +89,9 @@ def test_download_url_pattern(empalme_data: dict) -> None:
 def test_2013_typo_documented(empalme_data: dict) -> None:
     """2013 ZIP filename must preserve DANE's typo and document it in notes."""
     entry = empalme_data["data"]["2013"]
-    assert (
-        entry["zip_filename"] == "GEIH_Emplame_2013.zip"
-    ), "2013 filename must keep DANE's typo ('Emplame' not 'Empalme')"
+    assert entry["zip_filename"] == "GEIH_Emplame_2013.zip", (
+        "2013 filename must keep DANE's typo ('Emplame' not 'Empalme')"
+    )
     assert entry["notes"] is not None, "2013 notes must not be null"
     assert "typo" in entry["notes"].lower(), "2013 notes must document the filename typo"
 


### PR DESCRIPTION
## Summary

Adds the catalog registry for the GEIH Empalme series (2010–2020), which re-estimates monthly GEIH microdata under the unified Marco 2005 methodology — the only path to a consistent multi-year time series before the 2022 redesign.

**New files (Curator scope only):**
- `pulso/data/empalme_sources.json` — 11 annual entries
- `pulso/data/schemas/empalme_sources.schema.json` — standalone JSON Schema (v2020-12)
- `tests/unit/test_empalme_sources.py` — 10 unit + 1 integration test

---

## Discovery findings

### Granularity
Each download is **one annual ZIP per year** (not 12 monthly ZIPs). Inside each annual ZIP are 12 monthly sub-ZIPs (e.g. `GEIH_Empalme_2015/1. Enero.zip`), each containing CSV files in Cabecera/Resto format → `geih_2006_2020` epoch applies.

### Catalog table (verified via HTTP HEAD)

| Year | Catalog ID | IDNO | Resource ID | Size (bytes) |
|------|-----------|------|-------------|-------------|
| 2010 | 765 | DANE-DIMPE-GEIH-EMPALME-2010 | 22001 | 219,702,328 |
| 2011 | 755 | DANE-DIMPE-GEIH-EMPALME-2011 | 21719 | 224,312,554 |
| 2012 | 760 | DANE-DIMPE-GEIH-EMPALME-2012 | 21879 | 261,280,670 |
| 2013 | 761 | DANE-DIMPE-GEIH-EMPALME-2013 | 21903 | 252,617,638 |
| 2014 | 756 | DANE-DIMPE-GEIH-EMPALME-2014 | 21743 | 258,217,796 |
| 2015 | 762 | DANE-DIMPE-GEIH-EMPALME-2015 | 21928 | 229,540,468 |
| 2016 | 757 | DANE-DIMPE-GEIH-EMPALME-2016 | 21776 | 230,131,436 |
| 2017 | 763 | DANE-DIMPE-GEIH-EMPALME-2017 | 21947 | 234,080,087 |
| 2018 | 758 | DANE-DIMPE-GEIH-EMPALME-2018 | 21795 | 234,063,925 |
| 2019 | 759 | DANE-DIMPE-GEIH-EMPALME-2019 | 21814 | 231,904,344 |
| 2020 | 764 | DANE-DIMPE-GEIH-EMPAL-2020 | — | *(not published)* |

All 10 active URLs return HTTP 200 + `Content-Length` matching recorded `size_bytes`.

### Deviations from issue schema suggestion

1. **`schema_version` pattern** — issue suggested `^\d+\.\d+\.\d+$` (semver). Used `^\d+\.\d+$` (major.minor) since this is a new standalone schema without a patch dimension. Value is `"1.0"`.
2. **Added `scraped_at` to metadata** — records when the catalog was verified, consistent with `sources.json` style.
3. **Added `test_download_url_pattern` and `test_catalog_ids_are_unique`** beyond the minimum spec — low-cost guards against data entry errors.
4. **Integration test asserts exact `Content-Length == size_bytes`** rather than just `> 0`, giving a signal if DANE updates a file without notice.

### Anomalies documented in data

- **2020** (`DANE-DIMPE-GEIH-EMPAL-2020`): catalog record exists but ZIP unpublished as of 2026-05-01. `downloadable: false`, all file fields null.
- **2013**: DANE filename typo `GEIH_Emplame_2013.zip` (missing `p`). Preserved as-is in `zip_filename`; explained in `notes`.

---

## Test output

```
tests/unit/test_empalme_sources.py::test_schema_validates_empalme_sources PASSED
tests/unit/test_empalme_sources.py::test_all_11_years_present PASSED
tests/unit/test_empalme_sources.py::test_idno_2020_anomaly PASSED
tests/unit/test_empalme_sources.py::test_idno_pattern_other_years PASSED
tests/unit/test_empalme_sources.py::test_2020_not_downloadable PASSED
tests/unit/test_empalme_sources.py::test_2010_to_2019_downloadable PASSED
tests/unit/test_empalme_sources.py::test_download_url_pattern PASSED
tests/unit/test_empalme_sources.py::test_2013_typo_documented PASSED
tests/unit/test_empalme_sources.py::test_schema_version PASSED
tests/unit/test_empalme_sources.py::test_catalog_ids_are_unique PASSED
tests/unit/test_empalme_sources.py::test_download_urls_resolvable SKIPPED (needs --run-integration)

10 passed, 1 skipped — full unit suite: 171 passed, 1 skipped
```

ruff format + ruff check: all passed.

---

## Next steps for PR #2 — Builder (`feat/code-empalme-loader`)

The Builder will need to:
1. Read `empalme_sources.json` via a new registry function (e.g. `_load_empalme_sources()`).
2. Implement `download_empalme_zip(year)` — cache key should be `empalme/{year}.zip` (distinct from monthly `raw/{year}/{month}/` slots).
3. Implement `parse_empalme_year(year)` — unzip the annual ZIP, iterate the 12 monthly sub-ZIPs, call `parse_shape_a_module()` for each month, tag rows with `year`/`month` columns.
4. Expose a public `load_empalme(year, module, area, harmonize)` API.
5. The 2020 entry (`downloadable: false`) should raise a clear `DataNotAvailableError` rather than attempting a download.

@Stebandido77

🤖 Generated with [Claude Code](https://claude.com/claude-code)