### PR TITLE
data(empalme): populate sha256 checksums for 10 downloadable catalogs

### DIFF
--- a/pulso/data/empalme_sources.json
+++ b/pulso/data/empalme_sources.json
@@ -3,7 +3,7 @@
     "schema_version": "1.0",
     "data_version": "2020",
     "description": "Annual GEIH Empalme microdata catalogs (2010-2020). Each download is one ZIP per year containing 12 monthly sub-ZIPs with Cabecera/Resto structure (geih_2006_2020 epoch). Download URLs verified via HTTP HEAD on 2026-05-01. 2020 catalog exists on DANE portal but the ZIP has not been published.",
-    "scraped_at": "2026-05-01T00:00:00Z"
+    "scraped_at": "2026-05-02T00:00:00Z"
   },
   "data": {
     "2010": {
@@ -14,7 +14,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/765",
       "zip_filename": "GEIH_Empalme_2010.zip",
       "size_bytes": 219702328,
-      "checksum_sha256": null,
+      "checksum_sha256": "117bc35cbcdc56cc64b4282a8497f6608e45ad07d58c6f5a67fead7abf948140",
       "notes": null
     },
     "2011": {
@@ -25,7 +25,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/755",
       "zip_filename": "GEIH_Empalme_2011.zip",
       "size_bytes": 224312554,
-      "checksum_sha256": null,
+      "checksum_sha256": "c2352f46e2023d1e71ff99415afcf01e0b9605b2e2b62dd773e14c22a540dccb",
       "notes": null
     },
     "2012": {
@@ -36,7 +36,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/760",
       "zip_filename": "GEIH_Empalme_2012.zip",
       "size_bytes": 261280670,
-      "checksum_sha256": null,
+      "checksum_sha256": "22a10ae2163a8536fc7d6451cd884ca3f61749a85822b94ac11cf0182aa558c1",
       "notes": null
     },
     "2013": {
@@ -47,7 +47,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/761",
       "zip_filename": "GEIH_Emplame_2013.zip",
       "size_bytes": 252617638,
-      "checksum_sha256": null,
+      "checksum_sha256": "d7ab57fac1dd78aeafa26059ff18a6540241b34f4f68ba31a8d6a963467c02cb",
       "notes": "DANE typo in ZIP filename: 'GEIH_Emplame_2013.zip' (missing 'p' in Empalme). This is the actual filename served by the server and must be preserved as-is."
     },
     "2014": {
@@ -58,7 +58,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/756",
       "zip_filename": "GEIH_Empalme_2014.zip",
       "size_bytes": 258217796,
-      "checksum_sha256": null,
+      "checksum_sha256": "6da4a1cfe30a885cc87d329278414001a9311ff40f69f30a222704ccc0b03fd0",
       "notes": null
     },
     "2015": {
@@ -69,7 +69,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/762",
       "zip_filename": "GEIH_Empalme_2015.zip",
       "size_bytes": 229540468,
-      "checksum_sha256": null,
+      "checksum_sha256": "cde835eb5575733aa5b80da86c0054de0e890dcaed056931f5839aa5a134e653",
       "notes": null
     },
     "2016": {
@@ -80,7 +80,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/757",
       "zip_filename": "GEIH_Empalme_2016.zip",
       "size_bytes": 230131436,
-      "checksum_sha256": null,
+      "checksum_sha256": "d08372d7b22456937eb8c693126df0985bea331672ffb6f8877559075017c1db",
       "notes": null
     },
     "2017": {
@@ -91,7 +91,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/763",
       "zip_filename": "GEIH_Empalme_2017.zip",
       "size_bytes": 234080087,
-      "checksum_sha256": null,
+      "checksum_sha256": "24bc5f0b7ef4a6bacfd4444626733526362d4ed154d6cb7e948e4a7a9599bb7d",
       "notes": null
     },
     "2018": {
@@ -102,7 +102,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/758",
       "zip_filename": "GEIH_Empalme_2018.zip",
       "size_bytes": 234063925,
-      "checksum_sha256": null,
+      "checksum_sha256": "10dab7928571389c8c4a130c5f3831e3b45e40995f5a52f9deb8ff85cdc473a5",
       "notes": null
     },
     "2019": {
@@ -113,7 +113,7 @@
       "landing_page": "https://microdatos.dane.gov.co/index.php/catalog/759",
       "zip_filename": "GEIH_Empalme_2019.zip",
       "size_bytes": 231904344,
-      "checksum_sha256": null,
+      "checksum_sha256": "455871963a7d921ef8452007af8f9eb9177f1608fdefe15e80fa7f8431097e53",
       "notes": null
     },
     "2020": {

--- a/tests/unit/test_empalme_sources.py
+++ b/tests/unit/test_empalme_sources.py
@@ -107,6 +107,24 @@ def test_catalog_ids_are_unique(empalme_data: dict) -> None:
     assert len(ids) == len(set(ids)), f"Duplicate catalog_ids: {ids}"
 
 
+def test_all_downloadable_have_checksum(empalme_data: dict) -> None:
+    """Every downloadable entry must have a 64-char hex SHA-256 checksum."""
+    import re
+
+    hex64 = re.compile(r"^[a-f0-9]{64}$")
+    for year, entry in empalme_data["data"].items():
+        if entry["downloadable"]:
+            cs = entry["checksum_sha256"]
+            assert cs is not None, f"Year {year}: checksum_sha256 must not be null"
+            assert isinstance(cs, str), f"Year {year}: checksum_sha256 must be a string"
+            assert hex64.match(cs), f"Year {year}: checksum_sha256 must be 64 hex chars, got {cs!r}"
+        else:
+            # Non-downloadable entries must keep checksum null
+            assert entry["checksum_sha256"] is None, (
+                f"Year {year}: non-downloadable entry must have checksum_sha256 null"
+            )
+
+
 @pytest.mark.integration
 def test_download_urls_resolvable(empalme_data: dict) -> None:
     """All active download URLs must return HTTP 200 with Content-Length > 0."""


### PR DESCRIPTION
## Summary

Fills the `checksum_sha256` field for all 10 downloadable entries in `pulso/data/empalme_sources.json`.  The checksums were computed by downloading each ~230 MB annual ZIP via streaming SHA256 (64 KB chunks) and verifying that `size_bytes` received from DANE matches the registry exactly.

**Files changed (Curator scope only):**
- `pulso/data/empalme_sources.json` — 10 checksums populated, `metadata.scraped_at` updated
- `tests/unit/test_empalme_sources.py` — new `test_all_downloadable_have_checksum` test

---

## Checksum table

| Year | Catalog ID | SHA256 (first 16 chars) | Full SHA256 | Size match |
|------|-----------|------------------------|-------------|------------|
| 2010 | 765 | `117bc35cbcdc56cc` | `117bc35cbcdc56cc64b4282a8497f6608e45ad07d58c6f5a67fead7abf948140` | ✓ 219,702,328 bytes |
| 2011 | 755 | `c2352f46e2023d1e` | `c2352f46e2023d1e71ff99415afcf01e0b9605b2e2b62dd773e14c22a540dccb` | ✓ 224,312,554 bytes |
| 2012 | 760 | `22a10ae2163a8536` | `22a10ae2163a8536fc7d6451cd884ca3f61749a85822b94ac11cf0182aa558c1` | ✓ 261,280,670 bytes |
| 2013 | 761 | `d7ab57fac1dd78ae` | `d7ab57fac1dd78aeafa26059ff18a6540241b34f4f68ba31a8d6a963467c02cb` | ✓ 252,617,638 bytes |
| 2014 | 756 | `6da4a1cfe30a885c` | `6da4a1cfe30a885cc87d329278414001a9311ff40f69f30a222704ccc0b03fd0` | ✓ 258,217,796 bytes |
| 2015 | 762 | `cde835eb5575733a` | `cde835eb5575733aa5b80da86c0054de0e890dcaed056931f5839aa5a134e653` | ✓ 229,540,468 bytes |
| 2016 | 757 | `d08372d7b2245693` | `d08372d7b22456937eb8c693126df0985bea331672ffb6f8877559075017c1db` | ✓ 230,131,436 bytes |
| 2017 | 763 | `24bc5f0b7ef4a6ba` | `24bc5f0b7ef4a6bacfd4444626733526362d4ed154d6cb7e948e4a7a9599bb7d` | ✓ 234,080,087 bytes |
| 2018 | 758 | `10dab7928571389c` | `10dab7928571389c8c4a130c5f3831e3b45e40995f5a52f9deb8ff85cdc473a5` | ✓ 234,063,925 bytes |
| 2019 | 759 | `455871963a7d921e` | `455871963a7d921ef8452007af8f9eb9177f1608fdefe15e80fa7f8431097e53` | ✓ 231,904,344 bytes |

**2020**: `downloadable=false`, `checksum_sha256=null` — unchanged.

**Size anomalies**: None. All 10 `size_bytes` from DANE's `Content-Length` match the registry values recorded in PR #39 exactly.

---

## Registry diff

Only two fields change per entry: `checksum_sha256` (`null` → 64-char hex string).  
Metadata: `scraped_at` updated to `2026-05-02T00:00:00Z`.  
All other fields (URLs, catalog IDs, IDNOs, notes) are untouched.

---

## Test output

```
tests/unit/test_empalme_sources.py::test_schema_validates_empalme_sources PASSED
tests/unit/test_empalme_sources.py::test_all_11_years_present PASSED
tests/unit/test_empalme_sources.py::test_idno_2020_anomaly PASSED
tests/unit/test_empalme_sources.py::test_idno_pattern_other_years PASSED
tests/unit/test_empalme_sources.py::test_2020_not_downloadable PASSED
tests/unit/test_empalme_sources.py::test_2010_to_2019_downloadable PASSED
tests/unit/test_empalme_sources.py::test_download_url_pattern PASSED
tests/unit/test_empalme_sources.py::test_2013_typo_documented PASSED
tests/unit/test_empalme_sources.py::test_schema_version PASSED
tests/unit/test_empalme_sources.py::test_catalog_ids_are_unique PASSED
tests/unit/test_empalme_sources.py::test_all_downloadable_have_checksum PASSED
tests/unit/test_empalme_sources.py::test_download_urls_resolvable SKIPPED (needs --run-integration)

11 passed, 1 skipped — full unit suite: 180 passed, 1 skipped
```

ruff format + ruff check: all passed.

---

@Stebandido77 — merge-ready. Closes the empalme registry validation loop for Phase 3.5. The 10 checksums allow `download_empalme_zip()` to verify file integrity after download (future enhancement — the current downloader skips checksum verification when `checksum_sha256` is null, which is no longer the case for these entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)