### PR TITLE
docs(phase4-C): formal architecture documentation (bilingual)

### DIFF
--- a/docs/architecture.es.md
+++ b/docs/architecture.es.md
@@ -1,0 +1,473 @@
+# pulso — Arquitectura del sistema
+
+> Este documento es la referencia arquitectónica principal del repositorio `pulso`.  
+> Cubre las tres shapes de CSV, el flujo completo del pipeline, organización del código,  
+> capa de datos, modelo de construcción multi-agente, estrategia de tests y problemas conocidos.  
+>
+> **English version:** [`docs/architecture.md`](architecture.md)  
+> **Decisiones relacionadas:** [`docs/decisions/`](decisions/)
+
+---
+
+## 1. Descripción general
+
+`pulso` da acceso Python directo a la **Gran Encuesta Integrada de Hogares (GEIH)** — la encuesta mensual de hogares del mercado laboral colombiano publicada por el DANE.
+
+```
+Solicitud del usuario: load(year=2024, month=6, module="ocupados")
+        │
+        ▼
+  ┌──────────────────────────────────────────────────────────────────┐
+  │  API pública de pulso  (pulso/_core/loader.py)                   │
+  │                                                                   │
+  │  descarga → parseo → (merge) → armonización → pd.DataFrame       │
+  └──────────────────────────────────────────────────────────────────┘
+        │          │           │            │
+        ▼          ▼           ▼            ▼
+   ZIP DANE    parser       claves       variable_map
+  (cacheado)  por shape     época         .json
+```
+
+**Contrato público:**
+- Entrada: año, mes, nombre de módulo (string), área (cabecera/resto/total)
+- Salida: `pd.DataFrame` con códigos de columna DANE crudos o variables canónicas armonizadas
+- Efectos secundarios: ZIP cacheado localmente; llamadas posteriores usan el caché
+
+**Qué NO hace `pulso`:**
+- Inferencia estadística (sin errores estándar que respeten el diseño muestral)
+- Imputación o relleno de datos faltantes
+- Productos oficiales del DANE — es un wrapper de conveniencia, no una herramienta oficial
+
+---
+
+## 2. Las tres shapes de CSV
+
+El hecho estructural más importante de `pulso` es que maneja tres layouts de CSV distintos producidos por el DANE en distintas series y años. Cada shape requiere lógica de parseo diferente.
+
+```
+Shape A  (GEIH-1, 2006–2021)    Shape B  (GEIH-2, 2022–presente)   Shape C  (Empalme, 2010–2019)
+──────────────────────────────  ────────────────────────────────────  ────────────────────────────
+zip_anual/                      zip_anual/                            empalme_YYYY.zip/
+  Cabecera - Ocupados.csv   →     CSV/                                  1. Enero.zip/
+  Resto    - Ocupados.csv           Ocupados.CSV                            1. Enero/CSV/
+  Cabecera - Caract.csv              Características...CSV                      Ocupados.CSV
+  Resto    - Caract.csv              No ocupados.CSV                             Caract. gen..CSV
+  ...                                ...                                       ...
+(split cabecera/resto)          (archivo único nacional,             (anidado: anual→mensual→módulo;
+                                 columna CLASE para filtrar área)     estructura Shape C en sub-ZIPs)
+```
+
+### Shape A — GEIH-1 (2006-01 → 2021-12)
+
+| Atributo | Valor |
+|----------|-------|
+| **Detección** | `is_shape_a(zip_path)`: algún archivo contiene `"Cabecera"` en su nombre |
+| **Estructura** | Dos archivos por módulo: `Cabecera - {módulo}.csv` (urbano) y `Resto - {módulo}.csv` (rural) |
+| **Codificación** | `latin-1` |
+| **Separador** | `;` (sin auto-detección para Shape A) |
+| **Decimal** | `,` |
+| **División área** | Separación física de archivos (no necesita columna `CLASE`) |
+| **Mayúsculas/minúsculas** | Mixto — varía por año y módulo (ej. `Hogar`, `Directorio`, `Fex_c_2011`) |
+| **Normalización de columnas** | ⚠️ **INCOMPLETA** — solo se ponen en mayúsculas las claves de merge; columnas no clave pueden quedar en minúsculas. Bug conocido: issue [#42](https://github.com/Stebandido77/pulso/issues/42). Corrección en Phase 4 Línea A. |
+| **Columna de peso** | `fex_c_2011` (minúsculas, con sufijo de año) → pasará a `FEX_C` tras la corrección de Línea A |
+| **Punto de entrada del parser** | `parse_shape_a_module()` en [`pulso/_core/parser.py`](../pulso/_core/parser.py) |
+
+El matching de archivos de módulos usa regex de límite de palabra contra el mapa `MODULE_KEYWORDS_GEIH1`, que maneja errores tipográficos en nombres de archivo del DANE (ej. `"Caractericas"` por `"Características"` en 2007).
+
+### Shape B — GEIH-2 (2022-01 → presente)
+
+| Atributo | Valor |
+|----------|-------|
+| **Detección** | `is_shape_a()` retorna `False` (no hay archivos con `"Cabecera"`) |
+| **Estructura** | Un CSV nacional único por módulo dentro de una carpeta `CSV/` |
+| **Codificación** | `latin-1` |
+| **Separador** | `;` declarado en la época; auto-detección de respaldo (algunos meses traen `,`) |
+| **Decimal** | `,` |
+| **División área** | A nivel de fila mediante columna `CLASE` (1 = cabecera, 2/3 = resto) |
+| **Mayúsculas/minúsculas** | Mayúsculas nativas del DANE |
+| **Normalización de columnas** | ✅ Stripping de BOM + mayúsculas en claves de merge via `_read_csv_with_fallback()` |
+| **Columna de peso** | `FEX_C18` (mayúsculas, sin sufijo de año) |
+| **Punto de entrada del parser** | `_parse_csv()` en [`pulso/_core/parser.py`](../pulso/_core/parser.py) |
+
+El fallback de auto-detección de separador (`sep=None, engine="python"`) se activa cuando `_read_csv_with_fallback()` lee un DataFrame de una sola columna, señal de separador incorrecto. Fue necesario para la entrada 2022-01 (ver PR [#36](https://github.com/Stebandido77/pulso/pull/36)).
+
+### Shape C — Empalme (2010-2019)
+
+| Atributo | Valor |
+|----------|-------|
+| **Detección** | Se invoca explícitamente via `load_empalme()` o `apply_smoothing=True`; no se auto-detecta |
+| **Estructura** | ZIP anual → 12 sub-ZIPs mensuales → `<NN>. <Mes>/CSV/<NombreMódulo>.CSV` |
+| **Codificación** | `latin-1` |
+| **Separador** | `;` con auto-detección de respaldo (heredado de `_read_csv_with_fallback`) |
+| **Decimal** | `,` |
+| **División área** | Archivo unificado; columna `CLASE` si está presente |
+| **Mayúsculas/minúsculas** | Mixto — el DANE entrega `Hogar`, `Fex_c_2011`, etc. |
+| **Normalización de columnas** | ✅ Mayúsculas completas + `FEX_C_XXXX → FEX_C` via `_normalize_empalme_columns()` |
+| **Columna de peso** | `FEX_C` (tras normalización) |
+| **Punto de entrada del parser** | `_parse_empalme_module()` en [`pulso/_core/empalme.py`](../pulso/_core/empalme.py) |
+
+El naming de los sub-ZIPs usa nombres de meses en español (`Enero`, `Febrero`, …, `Diciembre`). La función `_detect_month_from_name()` extrae el número de mes del nombre del sub-ZIP.
+
+**Anomalías documentadas en el registry:**
+- **2013:** el ZIP exterior tiene un error tipográfico del DANE `GEIH_Emplame_2013.zip` (falta una `p`); se preserva tal cual.
+- **2020:** ZIP no publicado por el DANE; `download_empalme_zip(2020)` lanza `DataNotAvailableError`.
+- **IDNO 2020:** truncado a `DANE-DIMPE-GEIH-EMPAL-2020` (le falta el sufijo `ME`).
+
+---
+
+## 3. Flujo del pipeline
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                       load() / load_merged()                         │
+│                     pulso/_core/loader.py                            │
+└─────────────────────────────────────────────────────────────────────┘
+    │
+    ▼
+┌────────────────────────────────────┐
+│  1. CONSULTA AL REGISTRO           │   pulso/_config/registry.py
+│  sources.json → registro (año,mes) │   Lanza DataNotAvailableError si falta
+│  epoch_for_month() → Epoch         │   pulso/_config/epochs.py
+└────────────────────────────────────┘
+    │
+    ▼
+┌────────────────────────────────────┐
+│  2. DESCARGA                       │   pulso/_core/downloader.py
+│  download_zip(year, month) → Path  │   Caché: <raíz>/raw/{year}/{month}/{sha[:16]}.zip
+│  Verificación de checksum SHA-256  │   DownloadError si no coincide
+└────────────────────────────────────┘
+    │
+    ▼
+┌────────────────────────────────────┐
+│  3. PARSEO (según shape)           │   pulso/_core/parser.py  O  pulso/_core/empalme.py
+│  parse_module(zip_path, ...) →     │
+│    Shape A: parse_shape_a_module() │   Cabecera + Resto concatenados; CLASE sintético
+│    Shape B: _parse_csv()           │   CSV único; BOM strip + auto-detección sep
+│    Shape C: _parse_empalme_module()│   Sub-ZIP extraído a temp; normalización completa
+│  → pd.DataFrame crudo              │
+└────────────────────────────────────┘
+    │
+    ▼  (solo en load_merged / apply_smoothing)
+┌────────────────────────────────────┐
+│  4. MERGE (persona + hogar)        │   pulso/_core/merger.py
+│  merge_modules(module_dfs, epoch)  │   Auto-detecta nivel persona/hogar por módulo
+│  → pd.DataFrame fusionado          │   MergeError si faltan claves (ver issue #42)
+└────────────────────────────────────┘
+    │
+    ▼  (cuando harmonize=True)
+┌────────────────────────────────────┐
+│  5. ARMONIZACIÓN                   │   pulso/_core/harmonizer.py
+│  harmonize_dataframe(df, epoch)    │   Lee variable_map.json
+│  → columnas canónicas añadidas     │   keep_raw=True: columnas crudas se preservan
+│    (sexo, edad, condicion_activ…)  │   Errores se omiten con logger.warning
+└────────────────────────────────────┘
+    │
+    ▼
+┌────────────────────────────────────┐
+│  6. RETORNO pd.DataFrame           │
+│  Columnas DANE crudas + canónicas  │   Usuario llama expand() por separado si requiere
+└────────────────────────────────────┘
+```
+
+### Detalles de cada paso
+
+**Paso 1 — Consulta al registro**  
+`_load_sources()` lee `pulso/data/sources.json` (230 entradas; cacheado en memoria tras la primera carga). `epoch_for_month(year, month)` itera los dos registros de época y retorna el dataclass `Epoch` correspondiente. Lanza `ConfigError` si ninguna época cubre la fecha (es decir, antes de 2006-01).
+
+**Paso 2 — Descarga**  
+`download_zip()` verifica primero el caché local. El slot de caché es `<raíz>/raw/{year}/{month:02d}/{sha256[:16]}.zip`. Si el archivo existe y el checksum coincide, se retorna de inmediato. Si el campo checksum en `sources.json` es `null` (la mayoría de entradas GEIH-1), el archivo se retorna sin verificación una vez descargado. Un patrón de archivo `.tmp` evita que descargas parciales contaminen el caché.
+
+**Paso 3 — Parseo**  
+`parse_module()` despacha primero via `is_shape_a(zip_path)`. Si es `True`, corre la lógica Shape A independientemente del campo `epoch.area_filter`. Si es `False`, lee el registro de `sources.json` para las rutas de archivos y despacha a Shape B (`_parse_csv`). Shape C se invoca por separado via `empalme.py` y nunca pasa por `parse_module()`.
+
+**Paso 4 — Merge**  
+`merge_modules()` auto-detecta el nivel de cada módulo (persona vs hogar) verificando qué claves de merge están presentes. Los módulos de nivel persona se fusionan en `(DIRECTORIO, SECUENCIA_P, ORDEN)`; los de nivel hogar en `(DIRECTORIO, SECUENCIA_P, HOGAR)`, luego se hace un left-join al resultado de persona. El default `how="outer"` asegura que las personas aparezcan aunque no estén en algún módulo.
+
+**Paso 5 — Armonización**  
+`harmonize_dataframe()` itera las variables de `variable_map.json`, resuelve las columnas fuente para la época actual, aplica el transform declarado y añade el resultado como nueva columna. Las variables con columnas fuente faltantes emiten `logger.warning()` y se omiten — **no lanzan excepción**. Con `keep_raw=True` (defecto), las columnas DANE originales se preservan junto a las canónicas.
+
+---
+
+## 4. Organización del código — `pulso/_core/`
+
+```
+pulso/_core/
+├── downloader.py       # Descarga, caché, checksums
+├── parser.py           # Parseo Shape A + Shape B
+├── empalme.py          # Shape C (Empalme) exclusivamente
+├── harmonizer.py       # Transforms de variable_map
+├── merger.py           # Merge multi-módulo
+├── loader.py           # Orquestador de API pública
+└── expander.py         # Helper expand()
+```
+
+### `downloader.py`
+
+Responsable de: obtener ZIPs del DANE, cachear en disco, verificar SHA-256.
+
+Funciones clave:
+- `download_zip(year, month, cache, show_progress, allow_unvalidated)` — punto de entrada principal
+- `verify_checksum(path, expected_sha256)` — comparación SHA-256 en streaming
+
+Nota: el downloader deliberadamente **no** parsea — retorna un `Path` al ZIP local y nada más. Esta separación permite probar el parser con ZIPs pre-cacheados sin acceso a red.
+
+### `parser.py`
+
+Responsable de: parseo de Shape A y Shape B. Shape C **no está aquí** (ver `empalme.py`).
+
+Funciones clave:
+- `is_shape_a(zip_path)` — detecta Shape A verificando si hay `"Cabecera"` en el namelist
+- `find_shape_a_files(zip_path, module)` — matching por keyword+regex para archivos Cabecera/Resto
+- `parse_shape_a_module(zip_path, module, epoch)` — lee ambas mitades, las concatena, añade `CLASE` sintético
+- `_read_csv_with_fallback(raw_bytes, epoch)` — auto-detección de separador + BOM strip + mayúsculas en claves
+- `_resolve_zip_path(zf, path)` — tolera rutas con mojibake y prefijos de subcarpeta faltantes
+- `_parse_csv(zip_path, inner_path, epoch, columns)` — lector de archivo único Shape B
+- `parse_module(zip_path, year, month, module, area, epoch, columns)` — dispatcher de nivel superior
+
+El diccionario `MODULE_KEYWORDS_GEIH1` mapea nombres canónicos de módulos a listas de palabras clave en español para identificar archivos dentro de ZIPs Shape A. Múltiples keywords por módulo manejan los errores tipográficos de nombres del DANE.
+
+### `empalme.py`
+
+Responsable de: Shape C (Empalme) exclusivamente. Separado porque:
+1. El anidamiento anual→mensual→sub-ZIP es estructuralmente distinto de Shapes A/B.
+2. La serie Empalme tiene un registry propio (`empalme_sources.json`) y layout de caché distinto.
+3. La normalización de columnas para Shape C es actualmente más completa que para Shape A (tras el fix de Phase 4 Línea A, esta divergencia se resolverá con un helper compartido).
+
+Funciones clave:
+- `_load_empalme_registry()` / `_get_empalme_entry(year)` — acceso al registry con validación
+- `download_empalme_zip(year, show_progress)` — caché en `<raíz>/empalme/{year}.zip`
+- `_find_empalme_module_csv(zf, module)` — keyword match dentro de un sub-ZIP
+- `_parse_empalme_module(inner_zip_path, module)` — lee un CSV de módulo + aplica `_normalize_empalme_columns()`
+- `_normalize_empalme_columns(df)` — mayúsculas en todas las columnas + `FEX_C_XXXX → FEX_C`
+- `_load_empalme_month_merged(year, month, area, harmonize, variables)` — carga de un mes para `apply_smoothing`
+- `load_empalme(year, module, area, harmonize)` — API pública, 12 meses apilados
+
+### `harmonizer.py`
+
+Responsable de: aplicar los transforms de `variable_map.json` a un DataFrame crudo.
+
+Funciones clave:
+- `harmonize_dataframe(df, epoch, variables, keep_raw)` — punto de entrada; itera variables y añade columnas canónicas
+- `harmonize_variable(df, canonical_name, entry, epoch)` — aplica el transform de una variable
+- `_apply_recode()`, `_apply_compute()`, `_apply_cast()`, `_apply_coalesce()` — primitivas de transform
+
+Invariante de diseño: `harmonize_dataframe()` nunca lanza excepción ante columnas fuente faltantes — registra un warning y omite. Esto permite armonización parcial cuando no todos los módulos están cargados.
+
+### `merger.py`
+
+Responsable de: fusionar múltiples DataFrames de módulos usando las claves apropiadas de la época.
+
+Funciones clave:
+- `merge_modules(module_dfs, epoch, level, how)` — merge de nivel superior
+- `_detect_module_level(df, epoch)` — detección persona vs hogar por presencia de claves
+- `_merge_within_level(dfs_dict, keys, how)` — left-join repetido dentro de un nivel
+
+El merger elimina columnas no-clave compartidas de los DataFrames posteriores para evitar sufijos `_x`/`_y`. Las columnas identificadoras compartidas (`CLASE`, `DPTO`, variables de peso, `MES`, `HOGAR`) aparecen exactamente una vez.
+
+### `loader.py`
+
+Responsable de: la API pública. Orquesta los pasos del pipeline.
+
+Funciones clave:
+- `load(year, month, module, area, harmonize, columns, cache, show_progress, allow_unvalidated)` — módulo único
+- `load_merged(year, month, modules, area, harmonize, variables, cache, show_progress, allow_unvalidated, apply_smoothing)` — merge multi-módulo con swap Empalme opcional
+- `_required_modules_for_variables(variable_map, sources, epoch_key, requested_variables)` — expande automáticamente la lista de módulos cuando `harmonize=True` y el usuario especificó `variables=`
+
+El parámetro `apply_smoothing` activa `_load_empalme_month_merged()` para años 2010–2019. El año 2020 emite `UserWarning` y retrocede al GEIH crudo.
+
+---
+
+## 5. Capa de datos — `pulso/data/`
+
+Este directorio es **territorio del Curator**. El Builder no debe modificar archivos aquí; el Curator no debe modificar `pulso/_core/`. CI hace cumplir esto via convenciones de path de branches.
+
+```
+pulso/data/
+├── sources.json              # 230 entradas mensuales GEIH (2006-01 → 2026-02)
+├── empalme_sources.json      # 11 entradas anuales Empalme (2010–2020)
+├── epochs.json               # 2 definiciones de épocas
+├── variable_map.json         # 30 mapeos de variables canónicas
+└── schemas/
+    ├── sources.schema.json
+    ├── empalme_sources.schema.json
+    ├── epochs.schema.json
+    └── variable_map.schema.json
+```
+
+### `sources.json`
+
+230 entradas con clave `"YYYY-MM"`. Cada entrada contiene:
+- `epoch`: `"geih_2006_2020"` o `"geih_2021_present"`
+- `download_url`: URL directa del ZIP del DANE
+- `checksum_sha256`: hex SHA-256 (5 entradas validadas completas; el resto `null`)
+- `modules`: rutas de archivos dentro del ZIP por módulo canónico
+- `validated`: `true/false`
+
+El schema en `sources.schema.json` hace cumplir dos shapes polimórficas de `ModuleFiles`:
+- `ModuleFilesSplit`: `{cabecera, resto}` (Shape A)
+- `ModuleFilesUnified`: `{file, row_filter?}` (Shape B)
+
+### `empalme_sources.json`
+
+11 entradas con clave de 4 dígitos (`"2010"` … `"2020"`). Cada entrada descargable tiene:
+- `catalog_id`, `idno`: identificadores del catálogo NADA del DANE
+- `download_url`, `zip_filename`, `size_bytes`, `checksum_sha256`
+- `downloadable`: `false` para 2020 (ZIP no publicado)
+
+Todas las 10 entradas descargables (2010–2019) tienen checksums SHA-256 verificados al 2026-05-02.
+
+### `epochs.json`
+
+Dos registros de época:
+
+| Clave | Rango de fechas | Etiqueta |
+|-------|----------------|---------|
+| `geih_2006_2020` | 2006-01 → 2021-12 | GEIH marco muestral 2005 |
+| `geih_2021_present` | **2022-01** → presente | GEIH rediseñada (post-OIT, marco 2018) |
+
+> ⚠️ El cambio de época está en **2022-01**, no en 2021. Esta es una fuente frecuente de confusión en la documentación.
+
+### `variable_map.json`
+
+30 variables canónicas mapeadas a través de ambas épocas. Cada entrada:
+- `type`: `numeric`, `categorical`, `string` o `boolean`
+- `level`: `persona` o `hogar`
+- `module`: nombre del módulo fuente
+- `mappings`: por época — `{source_variable, transform, source_doc, notes?}`
+
+Tipos de transform: `identity`, `recode`, `compute` (expresión pandas eval), `cast`, `coalesce`.
+
+---
+
+## 6. Modelo de construcción multi-agente
+
+`pulso` usa un modelo de tres roles donde cada uno tiene permisos distintos:
+
+```
+Architect      →   Diseño, ADRs, docs de arquitectura, RFCs de roadmap
+Builder        →   pulso/_core/, pulso/__init__.py, tests/
+Curator        →   pulso/data/, tests/
+```
+
+CI hace cumplir las convenciones de path de branches:
+
+| Prefijo de branch | Puede tocar |
+|------------------|------------|
+| `feat/code-*` | `pulso/_core/`, `pulso/__init__.py`, `tests/` |
+| `feat/data-*` | `pulso/data/`, `tests/` |
+| `docs/*`      | `docs/`, `README.md` |
+| `fix/code-*`  | Igual que `feat/code-*` |
+
+Las violaciones hacen fallar el CI. Esto previene cambios accidentales entre capas y mantiene una traza de auditoría limpia de quién cambió qué.
+
+**Por qué importa esto:** `sources.json` y `variable_map.json` contienen metadatos de calidad investigativa que el Curator debe validar antes de que el Builder pueda depender de ellos. Separar los branches asegura que estos archivos se revisen de forma independiente.
+
+---
+
+## 7. Decisiones arquitectónicas activas
+
+Ver [`docs/decisions/`](decisions/) para los registros completos de ADR.
+
+| ADR | Título | Estado |
+|-----|--------|--------|
+| [0001](decisions/0001-build-plan.md) | Plan de construcción y estructura de fases | Activo |
+| [0002](decisions/0002-scope-2006-present.md) | Alcance GEIH (solo 2006-presente, sin ECH) | Activo |
+| [0003](decisions/0003-schema-1.1-area-filtering.md) | Schema v1.1 ModuleFiles polimórfico | Activo |
+| [0004](decisions/0004-harmonizer-design.md) | Diseño del harmonizer (keep_raw=True por defecto) | Activo |
+| [0005](decisions/0005-phase4-roadmap.md) | Roadmap Phase 4 (C→A→v1.0→B→v1.1) | Activo |
+
+Invariantes activos clave:
+- **Cambio de época = 2022-01.** Verificado empíricamente via `epoch_for_month()`.
+- **`apply_smoothing` degrada graciosamente para año 2020.** Emite `UserWarning`, retrocede al GEIH crudo.
+- **`harmonize_dataframe` nunca lanza ante columnas faltantes.** Omite con `logger.warning`.
+- **El caché es de solo-adición.** Los ZIPs descargados nunca se sobreescriben salvo que el checksum falle; las descargas parciales usan sufijo `.tmp`.
+
+---
+
+## 8. Estrategia de tests
+
+```
+                    ┌─────────────────────────────────────────┐
+                    │            Suite de tests CI             │
+                    │                                          │
+                    │  Integración (275 tests)                 │
+                    │    @pytest.mark.integration              │
+                    │    Requiere flag --run-integration       │
+                    │    ZIPs reales del DANE desde red        │
+                    │    5 meses estratégicos validados        │
+                    │                                          │
+                    │  Unitarios (179 tests)                   │
+                    │    Rápidos, sin red                      │
+                    │    Fixtures sintéticos de ZIP            │
+                    │    Siempre corren en CI                  │
+                    └─────────────────────────────────────────┘
+```
+
+### Tests unitarios (179, siempre corren)
+
+Ubicación: `tests/unit/`
+
+- ZIPs fixture en `tests/fixtures/zips/` construidos por `tests/_build_fixtures.py`
+- `geih2_sample.zip` — fixture Shape A (Cabecera + Resto)
+- `geih2_unified_sample.zip` — fixture Shape B (archivo unificado)
+- Inyección de registry via `monkeypatch.setattr(reg, "_SOURCES", ...)` para evitar cargar `sources.json`
+
+### Tests de integración (275, requieren `--run-integration`)
+
+Ubicación: `tests/integration/`
+
+**5 meses estratégicos** validados con ZIPs reales del DANE:
+
+| Mes | Época | Shape | Por qué se eligió |
+|-----|-------|-------|-------------------|
+| 2007-12 | geih_2006_2020 | A | Entrada GEIH-1 más temprana estable; BOM en encabezados CSV |
+| 2015-06 | geih_2006_2020 | A | Bug de columnas mixtas (issue #42) confirmado aquí |
+| 2021-12 | geih_2006_2020 | A | Último mes antes del cambio de época |
+| 2022-01 | geih_2021_present | B | Primer mes de nueva época; anomalía de separador coma |
+| 2024-06 | geih_2021_present | B | Más reciente validado manualmente; ancla de regresión Phase 2 |
+
+**Test de regresión Phase 2:** `load_merged(year=2024, month=6, harmonize=True).shape == (70020, 525)` — este valor exacto está bloqueado y no debe cambiar.
+
+### Tests de integración del Empalme
+
+`tests/integration/test_smoothing.py`:
+- `test_smoothing_2015_06_real` — `apply_smoothing=True` para 2015-06 produce columnas normalizadas (FEX_C, HOGAR en mayúsculas) y conteo de filas plausible
+- `test_load_empalme_2015_real` — `load_empalme(2015)` retorna 12 meses apilados con FEX_C no nulo
+
+---
+
+## 9. Problemas conocidos
+
+### Issue #42 — Parser Shape A: columnas en minúsculas (severidad ALTA)
+
+**Estado:** Abierto. Previsto para Phase 4 Línea A.
+
+**Síntoma:** `load_merged(year, month)` para algunos meses GEIH-1 lanza `MergeError: Module is missing merge keys`. Confirmado para 2015-06 módulo `vivienda_hogares`.
+
+**Causa raíz:** El DANE entrega columnas como `Hogar`, `Area`, `Fex_c_2011` (mayúsculas y minúsculas mixtas) en algunos CSVs Shape A. La búsqueda sensible a mayúsculas del merger para `HOGAR` falla.
+
+**Solución temporal:** Ninguna para el path crudo. El path Empalme (`apply_smoothing=True`) normaliza columnas correctamente via `_normalize_empalme_columns()`.
+
+**Corrección planificada:** Phase 4 Línea A — extraer un helper compartido `_normalize_dane_columns()` en `parser.py`, aplicarlo en `parse_shape_a_module()`. Actualizar `variable_map.json` para usar `FEX_C` en vez de `fex_c_2011` (PRs coordinados Builder + Curator). Ver [ADR 0005](decisions/0005-phase4-roadmap.md).
+
+---
+
+## 10. Glosario
+
+| Término | Definición |
+|---------|-----------|
+| **GEIH** | Gran Encuesta Integrada de Hogares. Encuesta mensual oficial del mercado laboral de Colombia, publicada por el DANE desde 2007 (marco muestral rediseñado en 2022). |
+| **ECH** | Encuesta Continua de Hogares. Encuesta predecesora del DANE (2000–2005). No soportada por `pulso` por metodología incompatible. |
+| **GEIH-1** | Nombre informal para la GEIH bajo el marco muestral del Censo 2005 (2006-01 → 2021-12 en el modelo de épocas de `pulso`). |
+| **GEIH-2** | Nombre informal para la GEIH bajo el marco muestral del Censo 2018, rediseñada post-OIT (2022-01 → presente). |
+| **Empalme** | Serie GEIH Empalme publicada anualmente por el DANE (2010–2019) que re-estima los microdatos mensuales bajo el marco unificado del Censo 2005. Permite análisis de series de tiempo consistentes a través del rediseño de 2022. |
+| **Factor de expansión** | Peso muestral. Cada encuestado representa un conteo poblacional. `fex_c_2011` (GEIH-1) / `FEX_C18` (GEIH-2) / `FEX_C` (Empalme, normalizado). |
+| **Época** | Período durante el cual la metodología del DANE es internamente consistente. `pulso` define dos épocas; su límite es 2022-01. |
+| **Módulo** | Un archivo CSV temático dentro de un ZIP mensual GEIH. Ejemplos: `ocupados`, `caracteristicas_generales`. Cada módulo tiene un nivel de análisis (persona u hogar). |
+| **Nivel persona** | Microdatos a nivel del encuestado individual. Claves de merge: `DIRECTORIO`, `SECUENCIA_P`, `ORDEN`. |
+| **Nivel hogar** | Microdatos a nivel del hogar. Claves de merge: `DIRECTORIO`, `SECUENCIA_P`, `HOGAR`. |
+| **Shape A / B / C** | Nombres internos de `pulso` para los tres layouts estructurales de CSV producidos por el DANE (ver Sección 2). |
+| **Variable canónica** | Nombre de variable armonizada en `variable_map.json` (ej. `sexo`, `peso_expansion`) consistente entre épocas, en contraposición al código DANE crudo (`P6020`, `FEX_C18`). |
+| **Builder** | Rol en el modelo de construcción multi-agente responsable de `pulso/_core/`. |
+| **Curator** | Rol responsable de `pulso/data/` — archivos de registry, schemas, mapa de variables. |
+| **Architect** | Rol responsable de ADRs, RFCs y decisiones de diseño transversales. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,474 @@
+# pulso — Architecture
+
+> This document is the primary architectural reference for the `pulso` codebase.  
+> It covers the three CSV shapes, the full processing pipeline, code organization, data layer,  
+> build model, testing strategy, and known issues.  
+>
+> **Spanish mirror:** [`docs/architecture.es.md`](architecture.es.md)  
+> **Related decisions:** [`docs/decisions/`](decisions/)
+
+---
+
+## 1. Overview
+
+`pulso` gives Python users single-line access to Colombia's **Gran Encuesta Integrada de Hogares (GEIH)** — the monthly household labour-force survey published by DANE (Departamento Administrativo Nacional de Estadística).
+
+```
+User request: load(year=2024, month=6, module="ocupados")
+       │
+       ▼
+  ┌─────────────────────────────────────────────────────────────────┐
+  │  pulso public API  (pulso/_core/loader.py)                      │
+  │                                                                  │
+  │  download → parse → (merge) → harmonize → pd.DataFrame          │
+  └─────────────────────────────────────────────────────────────────┘
+       │         │          │          │
+       ▼         ▼          ▼          ▼
+  DANE ZIP   shape-aware  epoch     variable_map
+  (cached)   parser       keys      .json
+```
+
+**User-facing contract:**
+- Input: year, month, module name (string), area (cabecera/resto/total)
+- Output: `pd.DataFrame` with either raw DANE column codes or harmonized canonical variable names
+- Side effects: ZIP cached locally; subsequent calls hit cache
+
+**What pulso does NOT do:**
+- Statistical inference (no sampling-design-aware standard errors)
+- Imputation or missing-data filling
+- Official DANE data products — this is a convenience wrapper, not a DANE tool
+
+---
+
+## 2. The Three CSV Shapes
+
+The most important structural fact about `pulso` is that it handles three distinct CSV layouts produced by DANE across different series and years. Each shape requires different parsing logic.
+
+```
+Shape A  (GEIH-1, 2006–2021)    Shape B  (GEIH-2, 2022–present)   Shape C  (Empalme, 2010–2019)
+─────────────────────────────   ──────────────────────────────────   ─────────────────────────────
+annual_zip/                     annual_zip/                           empalme_YYYY.zip/
+  Cabecera - Ocupados.csv   →     CSV/                                  1. Enero.zip/
+  Resto    - Ocupados.csv           Ocupados.CSV                            1. Enero/CSV/
+  Cabecera - Caract.csv              Características...CSV                      Ocupados.CSV
+  Resto    - Caract.csv              No ocupados.CSV                             Caract. gen..CSV
+  ...                                ...                                       ...
+(split by urban/rural)          (single national file,             (nested: annual→monthly→module;
+                                 CLASE col for area filter)         Shape C-style inside sub-ZIPs)
+```
+
+### Shape A — GEIH-1 (2006-01 → 2021-12)
+
+| Attribute | Value |
+|-----------|-------|
+| **Detection** | `is_shape_a(zip_path)`: any filename contains `"Cabecera"` |
+| **Structure** | Two files per module: `Cabecera - {module}.csv` (urban) and `Resto - {module}.csv` (rural) |
+| **Encoding** | `latin-1` |
+| **Separator** | `;` (no auto-detect needed for Shape A) |
+| **Decimal** | `,` |
+| **Area split** | Physical file split (no `CLASE` column needed) |
+| **Column case** | Mixed — varies by year and module (e.g. `Hogar`, `Directorio`, `Fex_c_2011`) |
+| **Column normalization** | ⚠️ **INCOMPLETE** — only merge keys are uppercased; non-key columns may be mixed case. Known bug: issue [#42](https://github.com/Stebandido77/pulso/issues/42). Fix tracked in Phase 4 Line A. |
+| **Weight column** | `fex_c_2011` (lowercase, with year suffix) → will become `FEX_C` after Line A fix |
+| **Parser entry point** | `parse_shape_a_module()` in [`pulso/_core/parser.py`](../pulso/_core/parser.py) |
+
+Module file matching uses word-boundary regex against the keyword map `MODULE_KEYWORDS_GEIH1`, which handles DANE filename typos (e.g. `"Caractericas"` for `"Características"` in 2007).
+
+### Shape B — GEIH-2 (2022-01 → present)
+
+| Attribute | Value |
+|-----------|-------|
+| **Detection** | `is_shape_a()` returns `False` (no `"Cabecera"` filenames) |
+| **Structure** | Single nationwide CSV per module inside a `CSV/` folder |
+| **Encoding** | `latin-1` |
+| **Separator** | `;` declared in epoch; auto-detect fallback (some months use `,`) |
+| **Decimal** | `,` |
+| **Area split** | Row-level via `CLASE` column (1 = cabecera, 2/3 = resto) |
+| **Column case** | Native uppercase from DANE |
+| **Column normalization** | ✅ BOM stripping + merge-key uppercase via `_read_csv_with_fallback()` |
+| **Weight column** | `FEX_C18` (uppercase, no year suffix) |
+| **Parser entry point** | `_parse_csv()` in [`pulso/_core/parser.py`](../pulso/_core/parser.py) |
+
+The separator auto-detect fallback (`sep=None, engine="python"`) activates when `_read_csv_with_fallback()` reads a 1-column DataFrame, which signals a separator mismatch. This was necessary for the 2022-01 entry (see PR [#36](https://github.com/Stebandido77/pulso/pull/36)).
+
+### Shape C — Empalme (2010-2019)
+
+| Attribute | Value |
+|-----------|-------|
+| **Detection** | Called explicitly via `load_empalme()` or `apply_smoothing=True`; not auto-detected |
+| **Structure** | Annual ZIP → 12 monthly sub-ZIPs → `<NN>. <Mes>/CSV/<ModuleName>.CSV` |
+| **Encoding** | `latin-1` |
+| **Separator** | `;` with auto-detect fallback (inherited from `_read_csv_with_fallback`) |
+| **Decimal** | `,` |
+| **Area split** | Unified file; `CLASE` column used if present |
+| **Column case** | Mixed — DANE delivers `Hogar`, `Fex_c_2011`, etc. |
+| **Column normalization** | ✅ Full uppercase + `FEX_C_XXXX → FEX_C` via `_normalize_empalme_columns()` |
+| **Weight column** | `FEX_C` (after normalization) |
+| **Parser entry point** | `_parse_empalme_module()` in [`pulso/_core/empalme.py`](../pulso/_core/empalme.py) |
+
+Monthly sub-ZIP naming uses Spanish month names (`Enero`, `Febrero`, …, `Diciembre`). The `_detect_month_from_name()` function extracts the month number from the sub-ZIP filename.
+
+**Anomalies documented in registry:**
+- **2013:** outer ZIP filename has DANE typo `GEIH_Emplame_2013.zip` (missing `p`); preserved as-is.
+- **2020:** ZIP not published by DANE; `download_empalme_zip(2020)` raises `DataNotAvailableError`.
+- **2020 IDNO:** truncated to `DANE-DIMPE-GEIH-EMPAL-2020` (missing `ME` suffix).
+
+---
+
+## 3. Pipeline Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        load() / load_merged()                        │
+│                     pulso/_core/loader.py                            │
+└─────────────────────────────────────────────────────────────────────┘
+    │
+    ▼
+┌────────────────────────────────────┐
+│  1. REGISTRY LOOKUP                │   pulso/_config/registry.py
+│  sources.json → (year,month) record│   Raises DataNotAvailableError if missing
+│  epoch_for_month() → Epoch object  │   pulso/_config/epochs.py
+└────────────────────────────────────┘
+    │
+    ▼
+┌────────────────────────────────────┐
+│  2. DOWNLOAD                       │   pulso/_core/downloader.py
+│  download_zip(year, month) → Path  │   Cache: <cache_root>/raw/{year}/{month}/{sha[:16]}.zip
+│  Checksum verification (SHA-256)   │   DownloadError on mismatch
+└────────────────────────────────────┘
+    │
+    ▼
+┌────────────────────────────────────┐
+│  3. PARSE (shape-aware)            │   pulso/_core/parser.py  OR  pulso/_core/empalme.py
+│  parse_module(zip_path, ...) →     │
+│    Shape A: parse_shape_a_module() │   Cabecera + Resto concatenated; CLASE synthetic
+│    Shape B: _parse_csv()           │   Single CSV; BOM strip + sep auto-detect
+│    Shape C: _parse_empalme_module()│   Sub-ZIP extracted to temp; full normalization
+│  → raw pd.DataFrame               │
+└────────────────────────────────────┘
+    │
+    ▼  (only in load_merged / apply_smoothing)
+┌────────────────────────────────────┐
+│  4. MERGE (persona + hogar)        │   pulso/_core/merger.py
+│  merge_modules(module_dfs, epoch)  │   Auto-detects persona/hogar level per module
+│  → merged pd.DataFrame            │   MergeError if keys missing (see issue #42)
+└────────────────────────────────────┘
+    │
+    ▼  (when harmonize=True)
+┌────────────────────────────────────┐
+│  5. HARMONIZE                      │   pulso/_core/harmonizer.py
+│  harmonize_dataframe(df, epoch)    │   Reads variable_map.json
+│  → canonical column names appended │   keep_raw=True: raw columns preserved alongside
+│    (sexo, edad, condicion_activ…)  │   HarmonizationError skipped with logger.warning
+└────────────────────────────────────┘
+    │
+    ▼
+┌────────────────────────────────────┐
+│  6. RETURN pd.DataFrame            │
+│  Raw DANE columns + canonical cols │   User calls expand() separately if needed
+└────────────────────────────────────┘
+```
+
+### Step details
+
+**Step 1 — Registry lookup**  
+`_load_sources()` reads `pulso/data/sources.json` (230 entries; cached in memory after first load). `epoch_for_month(year, month)` iterates the two epoch records and returns the matching `Epoch` frozen dataclass. Raises `ConfigError` if no epoch covers the date (i.e. before 2006-01).
+
+**Step 2 — Download**  
+`download_zip()` checks the local cache first. The cache slot is `<cache_root>/raw/{year}/{month:02d}/{sha256[:16]}.zip`. If the file exists and the checksum matches, it is returned immediately. If the checksum field in `sources.json` is `null` (most GEIH-1 entries), the file is returned without verification once downloaded. A `.tmp` file pattern prevents partial downloads from polluting the cache.
+
+**Step 3 — Parse**  
+`parse_module()` dispatches first via `is_shape_a(zip_path)`. If `True`, Shape A logic runs regardless of the `epoch.area_filter` field. If `False`, it reads the `sources.json` record for file paths and dispatches to Shape B (`_parse_csv`). Shape C is invoked separately via `empalme.py` and never flows through `parse_module()`.
+
+**Step 4 — Merge**  
+`merge_modules()` auto-detects each module's level (persona vs hogar) by checking which merge keys are present. Persona-level modules are merged on `(DIRECTORIO, SECUENCIA_P, ORDEN)`; hogar-level modules are merged on `(DIRECTORIO, SECUENCIA_P, HOGAR)`, then left-joined into the persona result. The `how="outer"` default ensures persons appear even if absent from a module (e.g. employed persons are not in `desocupados`).
+
+**Step 5 — Harmonize**  
+`harmonize_dataframe()` iterates `variable_map.json` variables, resolves source columns for the current epoch, applies the declared transform (identity/recode/compute/cast/coalesce), and appends the result as a new column. Variables with missing source columns emit `logger.warning()` and are skipped — they do **not** raise an exception. With `keep_raw=True` (default), the original DANE columns are preserved alongside the canonical ones.
+
+---
+
+## 4. Code Organization — `pulso/_core/`
+
+```
+pulso/_core/
+├── downloader.py       # Download, cache, checksum
+├── parser.py           # Shape A + Shape B parsing
+├── empalme.py          # Shape C (Empalme) exclusively
+├── harmonizer.py       # variable_map transforms
+├── merger.py           # multi-module merge
+├── loader.py           # public API orchestrator
+└── expander.py         # expand() helper
+```
+
+### `downloader.py`
+
+Responsible for: fetching ZIPs from DANE, caching to disk, verifying SHA-256.
+
+Key functions:
+- `download_zip(year, month, cache, show_progress, allow_unvalidated)` — main entry point
+- `verify_checksum(path, expected_sha256)` — streaming SHA-256 comparison
+
+Notable: the downloader deliberately does **not** parse — it returns a `Path` to the local ZIP and nothing more. This separation allows the parser to be tested with pre-cached ZIPs without network access.
+
+### `parser.py`
+
+Responsible for: Shape A and Shape B parsing. Shape C is **not here** (see `empalme.py`).
+
+Key functions:
+- `is_shape_a(zip_path)` — detects Shape A by checking for `"Cabecera"` in namelist
+- `find_shape_a_files(zip_path, module)` — keyword+regex match for Cabecera/Resto files
+- `parse_shape_a_module(zip_path, module, epoch)` — reads both halves, concatenates, adds synthetic `CLASE`
+- `_read_csv_with_fallback(raw_bytes, epoch)` — separator auto-detect + BOM strip + merge-key uppercase
+- `_resolve_zip_path(zf, path)` — tolerates mojibake paths and missing subfolder prefixes
+- `_parse_csv(zip_path, inner_path, epoch, columns)` — Shape B single-file reader
+- `parse_module(zip_path, year, month, module, area, epoch, columns)` — top-level dispatcher
+
+The `MODULE_KEYWORDS_GEIH1` dictionary maps canonical module names to lists of Spanish keywords used to identify files inside Shape A ZIPs. Multiple keywords per module handle DANE's filename typos.
+
+### `empalme.py`
+
+Responsible for: Shape C (Empalme) exclusively. Kept separate because:
+1. The annual→monthly→sub-ZIP nesting is structurally different from Shapes A/B.
+2. The Empalme series has a distinct registry (`empalme_sources.json`) and cache layout.
+3. Column normalization for Shape C is currently more complete than for Shape A (post-Phase 4 Line A fix, this divergence will be resolved by a shared helper).
+
+Key functions:
+- `_load_empalme_registry()` / `_get_empalme_entry(year)` — registry access with validation
+- `download_empalme_zip(year, show_progress)` — cache at `<root>/empalme/{year}.zip`
+- `_find_empalme_module_csv(zf, module)` — keyword match inside a sub-ZIP
+- `_parse_empalme_module(inner_zip_path, module)` — reads one module CSV + applies `_normalize_empalme_columns()`
+- `_normalize_empalme_columns(df)` — uppercase all columns + `FEX_C_XXXX → FEX_C`
+- `_load_empalme_month_merged(year, month, area, harmonize, variables)` — single-month load for `apply_smoothing`
+- `load_empalme(year, module, area, harmonize)` — public API, all 12 months stacked
+
+### `harmonizer.py`
+
+Responsible for: applying `variable_map.json` transforms to a raw DataFrame.
+
+Key functions:
+- `harmonize_dataframe(df, epoch, variables, keep_raw)` — main entry point; iterates variables and appends canonical columns
+- `harmonize_variable(df, canonical_name, entry, epoch)` — applies a single variable's transform
+- `_apply_recode()`, `_apply_compute()`, `_apply_cast()`, `_apply_coalesce()` — transform primitives
+
+Design invariant: `harmonize_dataframe()` never raises on missing source columns — it logs a warning and skips. This allows partial harmonization when not all modules are loaded.
+
+### `merger.py`
+
+Responsible for: merging multiple module DataFrames using epoch-appropriate keys.
+
+Key functions:
+- `merge_modules(module_dfs, epoch, level, how)` — top-level merge
+- `_detect_module_level(df, epoch)` — persona vs hogar detection by key presence
+- `_merge_within_level(dfs_dict, keys, how)` — repeated left-join within a level
+
+The merger drops shared non-key columns from later DataFrames to avoid `_x`/`_y` suffixes. Shared identifier columns (`CLASE`, `DPTO`, weight variables, `MES`, `HOGAR`) appear exactly once.
+
+### `loader.py`
+
+Responsible for: the public API. Orchestrates the pipeline steps above.
+
+Key functions:
+- `load(year, month, module, area, harmonize, columns, cache, show_progress, allow_unvalidated)` — single module
+- `load_merged(year, month, modules, area, harmonize, variables, cache, show_progress, allow_unvalidated, apply_smoothing)` — multi-module merge with optional Empalme swap
+- `_required_modules_for_variables(variable_map, sources, epoch_key, requested_variables)` — auto-expands the module list when `harmonize=True` and the user specified `variables=`
+
+The `apply_smoothing` parameter triggers `_load_empalme_month_merged()` for years 2010–2019. Year 2020 emits `UserWarning` and falls back to raw GEIH.
+
+---
+
+## 5. Data Layer — `pulso/data/`
+
+This directory is **Curator territory**. The Builder must not modify files here; the Curator must not modify `pulso/_core/`. CI enforces this via branch path conventions.
+
+```
+pulso/data/
+├── sources.json              # 230 monthly GEIH entries (2006-01 → 2026-02)
+├── empalme_sources.json      # 11 annual Empalme entries (2010–2020)
+├── epochs.json               # 2 epoch definitions
+├── variable_map.json         # 30 canonical variable mappings
+└── schemas/
+    ├── sources.schema.json
+    ├── empalme_sources.schema.json
+    ├── epochs.schema.json
+    └── variable_map.schema.json
+```
+
+### `sources.json`
+
+230 entries keyed by `"YYYY-MM"`. Each entry contains:
+- `epoch`: `"geih_2006_2020"` or `"geih_2021_present"`
+- `download_url`: direct DANE ZIP URL
+- `checksum_sha256`: SHA-256 hex (5 validated entries filled; rest `null`)
+- `modules`: file paths inside the ZIP per canonical module
+- `validated`: `true/false`
+
+The schema in `sources.schema.json` enforces two polymorphic `ModuleFiles` shapes:
+- `ModuleFilesSplit`: `{cabecera, resto}` (Shape A)
+- `ModuleFilesUnified`: `{file, row_filter?}` (Shape B)
+
+### `empalme_sources.json`
+
+11 entries keyed by 4-digit year string (`"2010"` … `"2020"`). Each downloadable entry contains:
+- `catalog_id`, `idno`: DANE NADA catalog identifiers
+- `download_url`, `zip_filename`, `size_bytes`, `checksum_sha256`
+- `downloadable`: `false` for 2020 (ZIP not published)
+
+All 10 downloadable entries (2010–2019) have verified SHA-256 checksums as of 2026-05-02.
+
+### `epochs.json`
+
+Two epoch records:
+
+| Key | Date range | Label |
+|-----|-----------|-------|
+| `geih_2006_2020` | 2006-01 → 2021-12 | GEIH marco muestral 2005 |
+| `geih_2021_present` | **2022-01** → present | GEIH rediseñada (post-OIT, marco 2018) |
+
+> ⚠️ The epoch boundary is **2022-01**, not 2021. This is a common source of confusion in documentation.
+
+### `variable_map.json`
+
+30 canonical variables mapped across both epochs. Each entry:
+- `type`: `numeric`, `categorical`, `string`, or `boolean`
+- `level`: `persona` or `hogar`
+- `module`: source module name
+- `mappings`: per-epoch `{source_variable, transform, source_doc, notes?}`
+
+Transform types: `identity`, `recode`, `compute` (pandas eval expression), `cast`, `coalesce`.
+
+---
+
+## 6. Multi-Agent Build Model
+
+`pulso` uses a three-role build model where each role has distinct permissions:
+
+```
+Architect      →   Design, ADRs, architecture docs, roadmap RFCs
+Builder        →   pulso/_core/, pulso/__init__.py, tests/
+Curator        →   pulso/data/, tests/
+```
+
+CI enforces branch path conventions:
+
+| Branch prefix | May touch |
+|--------------|-----------|
+| `feat/code-*` | `pulso/_core/`, `pulso/__init__.py`, `tests/` |
+| `feat/data-*` | `pulso/data/`, `tests/` |
+| `docs/*`      | `docs/`, `README.md` |
+| `fix/code-*`  | Same as `feat/code-*` |
+
+Violations cause CI to fail. This prevents accidental cross-layer changes and maintains a clean audit trail of who changed what.
+
+**Why this matters:** `sources.json` and `variable_map.json` contain research-quality metadata that must be validated by the Curator before the Builder can depend on it. Separating branches ensures these files are reviewed independently.
+
+---
+
+## 7. Active Architectural Decisions
+
+See [`docs/decisions/`](decisions/) for full ADR records.
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](decisions/0001-build-plan.md) | Build plan and phase structure | Active |
+| [0002](decisions/0002-scope-2006-present.md) | GEIH scope (2006-present only, no ECH) | Active |
+| [0003](decisions/0003-schema-1.1-area-filtering.md) | Schema v1.1 polymorphic ModuleFiles | Active |
+| [0004](decisions/0004-harmonizer-design.md) | Harmonizer design (keep_raw=True default) | Active |
+| [0005](decisions/0005-phase4-roadmap.md) | Phase 4 roadmap (C→A→v1.0→B→v1.1) | Active |
+
+Key active invariants:
+- **Epoch boundary = 2022-01.** Empirically verified via `epoch_for_month()`.
+- **`apply_smoothing` degrades gracefully for year=2020.** Emits `UserWarning`, falls back to raw GEIH.
+- **`harmonize_dataframe` never raises on missing columns.** Skips with `logger.warning`.
+- **Cache is append-only.** Downloaded ZIPs are never overwritten unless checksum fails; partial downloads use `.tmp` suffix.
+
+---
+
+## 8. Testing Strategy
+
+```
+                    ┌─────────────────────────────────────────┐
+                    │            CI Test Suite                 │
+                    │                                          │
+                    │  Integration (275 tests)                 │
+                    │    @pytest.mark.integration              │
+                    │    --run-integration flag required       │
+                    │    Real DANE ZIPs from network           │
+                    │    5 strategic months validated          │
+                    │                                          │
+                    │  Unit (179 tests)                        │
+                    │    Fast, no network                      │
+                    │    Synthetic fixture ZIPs                │
+                    │    Always run in CI                      │
+                    └─────────────────────────────────────────┘
+```
+
+### Unit tests (179 tests, always run)
+
+Location: `tests/unit/`
+
+- Fixture ZIPs in `tests/fixtures/zips/` built by `tests/_build_fixtures.py`
+- `geih2_sample.zip` — Shape A fixture (Cabecera + Resto)
+- `geih2_unified_sample.zip` — Shape B fixture (unified file)
+- Registry injection via `monkeypatch.setattr(reg, "_SOURCES", ...)` to avoid loading `sources.json`
+- Parser tests verify BOM stripping, separator auto-detect, column normalization, keyword matching
+
+### Integration tests (275 tests, require `--run-integration`)
+
+Location: `tests/integration/`
+
+**5 strategic months** validated with real DANE ZIPs:
+
+| Month | Epoch | Shape | Why chosen |
+|-------|-------|-------|-----------|
+| 2007-12 | geih_2006_2020 | A | Earliest stable GEIH-1 entry; BOM in CSV headers |
+| 2015-06 | geih_2006_2020 | A | Mixed-case column bug (issue #42) confirmed here |
+| 2021-12 | geih_2006_2020 | A | Last month before epoch boundary |
+| 2022-01 | geih_2021_present | B | First month of new epoch; comma separator anomaly |
+| 2024-06 | geih_2021_present | B | Most recent manually validated; Phase 2 regression anchor |
+
+**Phase 2 regression test:** `load_merged(year=2024, month=6, harmonize=True).shape == (70020, 525)` — this exact value is locked and must not change.
+
+### Empalme integration tests
+
+`tests/integration/test_smoothing.py`:
+- `test_smoothing_2015_06_real` — `apply_smoothing=True` for 2015-06 produces normalized columns (FEX_C, HOGAR uppercase) and plausible row count
+- `test_load_empalme_2015_real` — `load_empalme(2015)` returns 12 months stacked with non-null FEX_C
+
+---
+
+## 9. Known Issues
+
+### Issue #42 — Shape A parser: mixed-case columns (HIGH severity)
+
+**Status:** Open. Tracked for Phase 4 Line A.
+
+**Symptom:** `load_merged(year, month)` for some GEIH-1 months raises `MergeError: Module is missing merge keys`. Confirmed for 2015-06 `vivienda_hogares` module.
+
+**Root cause:** DANE delivers columns like `Hogar`, `Area`, `Fex_c_2011` (mixed case) in some Shape A CSVs. The merger's case-sensitive lookup for `HOGAR` fails.
+
+**Current workaround:** None for the raw path. The Empalme path (`apply_smoothing=True`) normalizes columns correctly via `_normalize_empalme_columns()`.
+
+**Fix planned:** Phase 4 Line A — extract a shared `_normalize_dane_columns()` helper in `parser.py`, apply it in `parse_shape_a_module()`. Update `variable_map.json` to use `FEX_C` instead of `fex_c_2011` (coordinated Builder + Curator PRs). See [ADR 0005](decisions/0005-phase4-roadmap.md).
+
+---
+
+## 10. Glossary
+
+| Term | Definition |
+|------|-----------|
+| **GEIH** | Gran Encuesta Integrada de Hogares. Colombia's official monthly labour-force survey, published by DANE since 2007 (redesigned sampling frame in 2022). |
+| **ECH** | Encuesta Continua de Hogares. DANE's predecessor survey (2000–2005). Not supported by `pulso` due to incompatible methodology. |
+| **GEIH-1** | Informal name for GEIH under the 2005 census sampling frame (2006-01 → 2021-12 in `pulso`'s epoch model). |
+| **GEIH-2** | Informal name for GEIH under the 2018 census sampling frame, redesigned post-ILO (2022-01 → present). |
+| **Empalme** | DANE's annually-published harmonized GEIH series (2010–2019) that re-estimates monthly microdata under the unified 2005-census methodology. Enables consistent multi-year analysis across the 2022 redesign. |
+| **Factor de expansión** | Expansion factor (survey weight). Each respondent represents a population count. `fex_c_2011` (GEIH-1) / `FEX_C18` (GEIH-2) / `FEX_C` (Empalme, normalized). |
+| **Época (Epoch)** | A period during which DANE's methodology is internally consistent. `pulso` defines two epochs; their boundary is 2022-01. |
+| **Módulo** | A thematic CSV file within a GEIH monthly ZIP. Examples: `ocupados`, `caracteristicas_generales`. Each module is one analysis level (persona or hogar). |
+| **Persona level** | Microdata at the individual respondent level. Merge keys: `DIRECTORIO`, `SECUENCIA_P`, `ORDEN`. |
+| **Hogar level** | Microdata at the household level. Merge keys: `DIRECTORIO`, `SECUENCIA_P`, `HOGAR`. |
+| **Shape A / B / C** | `pulso`'s internal names for the three CSV structural layouts produced by DANE (see Section 2). |
+| **Canonical variable** | A harmonized variable name in `variable_map.json` (e.g. `sexo`, `peso_expansion`) that is consistent across epochs, as opposed to the raw DANE code (`P6020`, `FEX_C18`). |
+| **Builder** | Role in the multi-agent build model responsible for `pulso/_core/`. |
+| **Curator** | Role responsible for `pulso/data/` — registry files, schemas, variable map. |
+| **Architect** | Role responsible for ADRs, RFCs, and cross-cutting design decisions. |


### PR DESCRIPTION
Arranca Phase 4 Línea C según el roadmap aprobado en [docs/decisions/0005-phase4-roadmap.md](https://github.com/Stebandido77/pulso/blob/main/docs/decisions/0005-phase4-roadmap.md).

## Qué incluye

Crea `docs/architecture.md` (English) y `docs/architecture.es.md` (Español), ambos cubriendo:

1. **The three CSV shapes (A/B/C)** — primera documentación formal de los tres layouts DANE; tabla comparativa de encoding, separador, normalización de columnas, estado del bug #42
2. **Pipeline flow** — diagrama ASCII completo desde download hasta pd.DataFrame público, con detalle de cada paso
3. **Code organization** — qué hace cada uno de los 7 archivos en `pulso/_core/` y por qué están separados
4. **Data layer** — qué tiene cada archivo en `pulso/data/`, quién es su dueño (Curator), referencias a schemas
5. **Multi-agent build model** — Architect/Builder/Curator + tabla de branch enforcement que CI hace cumplir
6. **Active ADRs** — tabla de referencia a los 5 ADRs activos (incluyendo 0005 recién mergeado)
7. **Testing strategy** — pirámide 179 unit + 275 integration, los 5 meses estratégicos y por qué se eligieron
8. **Known issues** — issue #42 (Shape A mixed-case columns) documentado con severidad HIGH y fix planificado
9. **Glossary** — 15 términos clave en ambos idiomas

## Stats

| File | Lines | Words |
|------|-------|-------|
| `docs/architecture.md` | 474 | ~3,100 |
| `docs/architecture.es.md` | 473 | ~3,400 |

## Cierra parcialmente Phase 4

- ✅ Línea C (docs de arquitectura) — este PR
- 🔜 Línea A (parser fix issue #42) — siguiente PR (`fix/code-shape-a-column-normalization`)
- ⏳ Línea B (variable introspection) — diferido a v1.1

No toca código, solo `docs/`. Branch `docs/*` está exento del enforcement Builder/Curator.

@Stebandido77 — review when ready.