### PR TITLE
fix(parser): Shape A column normalization (closes #42)

### DIFF
--- a/pulso/_core/empalme.py
+++ b/pulso/_core/empalme.py
@@ -23,6 +23,7 @@ import requests
 from pulso._config.epochs import get_epoch
 from pulso._core.parser import MODULE_KEYWORDS_GEIH1, _read_csv_with_fallback
 from pulso._utils.cache import cache_path
+from pulso._utils.columns import _normalize_dane_columns
 from pulso._utils.exceptions import DataNotAvailableError, DownloadError, ParseError
 
 if TYPE_CHECKING:
@@ -143,43 +144,10 @@ def download_empalme_zip(year: int, show_progress: bool = True) -> Path:
 
 # ── Shape C parsing helpers ───────────────────────────────────────────────────
 
-_FEX_C_PATTERN: re.Pattern[str] = re.compile(r"^FEX_C(?:_\d{4})?$")
-
 
 def _normalize_empalme_columns(df: pd.DataFrame) -> pd.DataFrame:
-    """Uppercase all column names and normalize FEX_C year-variants to canonical FEX_C.
-
-    Empalme CSVs have mixed-case columns (e.g. 'Hogar', 'Area', 'Fex_c_2011').
-    The merger and harmonizer expect uppercase names; the weight column must be
-    FEX_C so the rest of the pipeline treats it consistently.
-
-    Step 1: uppercase all columns.
-    Step 2: rename FEX_C_XXXX → FEX_C (covers FEX_C_2011, FEX_C_2018, …).
-    If >1 FEX_C-pattern column is found (unexpected), warn and keep the first.
-    """
-    import warnings
-
-    df = df.copy()
-    df.columns = df.columns.str.upper()
-
-    fex_matches = [c for c in df.columns if _FEX_C_PATTERN.match(c)]
-
-    if len(fex_matches) > 1:
-        warnings.warn(
-            f"Multiple FEX_C-pattern columns found in empalme CSV: {fex_matches}. "
-            f"Keeping {fex_matches[0]!r} as 'FEX_C'; dropping the rest.",
-            UserWarning,
-            stacklevel=3,
-        )
-        df = df.drop(columns=fex_matches[1:])
-        if fex_matches[0] != "FEX_C":
-            df = df.rename(columns={fex_matches[0]: "FEX_C"})
-            logger.debug("Normalized %r → 'FEX_C' (multi-match path)", fex_matches[0])
-    elif len(fex_matches) == 1 and fex_matches[0] != "FEX_C":
-        df = df.rename(columns={fex_matches[0]: "FEX_C"})
-        logger.debug("Normalized column %r → 'FEX_C'", fex_matches[0])
-
-    return df
+    """Normalize Empalme CSV columns. Delegates to shared _normalize_dane_columns."""
+    return _normalize_dane_columns(df)
 
 
 def _detect_month_from_name(name: str) -> int | None:

--- a/pulso/_core/parser.py
+++ b/pulso/_core/parser.py
@@ -20,6 +20,7 @@ import zipfile
 from typing import TYPE_CHECKING, Literal, cast
 
 from pulso._config.registry import _load_sources
+from pulso._utils.columns import _normalize_dane_columns
 from pulso._utils.exceptions import ParseError
 
 if TYPE_CHECKING:
@@ -215,9 +216,8 @@ def parse_shape_a_module(
             df_resto["CLASE"] = 2
             dfs.append(df_resto)
 
-    if len(dfs) == 1:
-        return dfs[0]
-    return pd.concat(dfs, axis=0, ignore_index=True)
+    result = dfs[0] if len(dfs) == 1 else pd.concat(dfs, axis=0, ignore_index=True)
+    return _normalize_dane_columns(result)
 
 
 def _parse_csv(

--- a/pulso/_utils/columns.py
+++ b/pulso/_utils/columns.py
@@ -1,0 +1,50 @@
+"""Shared column-normalization utilities for DANE GEIH data."""
+
+from __future__ import annotations
+
+import re
+import warnings
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+_FEX_C_PATTERN: re.Pattern[str] = re.compile(r"^FEX_C(?:_\d{4})?$")
+
+
+def _normalize_dane_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Uppercase all column names and normalize FEX_C year-variants to canonical FEX_C.
+
+    DANE GEIH CSVs deliver mixed-case columns for some years/shapes (e.g. 'Hogar',
+    'Area', 'Fex_c_2011').  The merger and harmonizer expect uppercase names; the
+    weight column must be FEX_C so the rest of the pipeline treats it consistently.
+
+    Step 1: uppercase all columns.
+    Step 2: rename FEX_C_XXXX → FEX_C (covers FEX_C_2011, FEX_C_2018, …).
+    If >1 FEX_C-pattern column is found (unexpected), warn and keep the first.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    df = df.copy()
+    df.columns = df.columns.str.upper()
+
+    fex_matches = [c for c in df.columns if _FEX_C_PATTERN.match(c)]
+
+    if len(fex_matches) > 1:
+        warnings.warn(
+            f"Multiple FEX_C-pattern columns found: {fex_matches}. "
+            f"Keeping {fex_matches[0]!r} as 'FEX_C'; dropping the rest.",
+            UserWarning,
+            stacklevel=3,
+        )
+        df = df.drop(columns=fex_matches[1:])
+        if fex_matches[0] != "FEX_C":
+            df = df.rename(columns={fex_matches[0]: "FEX_C"})
+            logger.debug("Normalized %r → 'FEX_C' (multi-match path)", fex_matches[0])
+    elif len(fex_matches) == 1 and fex_matches[0] != "FEX_C":
+        df = df.rename(columns={fex_matches[0]: "FEX_C"})
+        logger.debug("Normalized column %r → 'FEX_C'", fex_matches[0])
+
+    return df

--- a/tests/integration/test_load_merged_2015_06.py
+++ b/tests/integration/test_load_merged_2015_06.py
@@ -1,0 +1,58 @@
+"""Integration tests confirming issue #42 is closed.
+
+load_merged(2015, 6) previously raised MergeError because vivienda_hogares
+returned mixed-case columns ('Hogar', 'Area', 'Fex_c_2011').  These tests
+validate that the Shape A normalizer fixes that.
+
+Run with: pytest -m integration --run-integration -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+def test_load_merged_2015_06_no_apply_smoothing() -> None:
+    """load_merged(2015, 6, harmonize=True) must complete without MergeError.
+
+    This is the primary regression test for issue #42.  The raw (non-smoothing)
+    path is exercised: Shape A parse → merge → harmonize.  Before the fix,
+    vivienda_hogares delivered mixed-case columns that caused the merger to raise
+    MergeError('Module is missing merge keys: expected [...] HOGAR').
+    """
+    import pulso
+
+    df = pulso.load_merged(2015, 6, harmonize=True)
+
+    assert df.shape[0] > 50_000, (
+        f"load_merged(2015, 6) must return plausible row count, got {df.shape[0]}"
+    )
+    assert df.shape[0] < 200_000, (
+        f"load_merged(2015, 6) row count suspiciously high (likely duplicated): {df.shape[0]}"
+    )
+
+
+@pytest.mark.integration
+def test_load_merged_2015_06_columns_uppercase() -> None:
+    """All raw DANE columns in the merged DataFrame must be uppercase post-load."""
+    import pulso
+
+    df = pulso.load_merged(2015, 6, harmonize=True)
+
+    raw_cols = [c for c in df.columns if c == c.upper() and not c.startswith("_")]
+    mixed_case = [c for c in df.columns if c != c.upper() and c != c.lower()]
+    assert not mixed_case, (
+        f"Found mixed-case raw columns after Shape A normalization: {mixed_case[:10]}"
+    )
+
+    assert "FEX_C" in df.columns or any(c.upper() == "FEX_C" for c in df.columns), (
+        "FEX_C canonical weight column must be present post-normalization"
+    )
+    assert "fex_c_2011" not in {c.lower() for c in df.columns}, (
+        "fex_c_2011 must have been renamed to FEX_C by _normalize_dane_columns"
+    )
+    assert "HOGAR" in df.columns or "hogar" in df.columns, (
+        "HOGAR merger key must be present (uppercase normalization)"
+    )
+    _ = raw_cols  # referenced above for clarity

--- a/tests/unit/test_parser_shape_a_normalization.py
+++ b/tests/unit/test_parser_shape_a_normalization.py
@@ -1,0 +1,73 @@
+"""Unit tests for Shape A column normalization via _normalize_dane_columns."""
+
+from __future__ import annotations
+
+import warnings
+
+import pandas as pd
+import pytest
+
+
+def _make_df(**cols: list) -> pd.DataFrame:
+    """Convenience: build a one-row DataFrame from keyword column names."""
+    return pd.DataFrame(dict(cols))
+
+
+# ── _normalize_dane_columns ───────────────────────────────────────────────────
+
+
+def test_normalize_shape_a_uppercases_all() -> None:
+    """All columns must be uppercased."""
+    from pulso._utils.columns import _normalize_dane_columns
+
+    df = _make_df(Hogar=[1], Area=[2], directorio=[3], FEX_C=[4.0])
+    result = _normalize_dane_columns(df)
+    assert list(result.columns) == ["HOGAR", "AREA", "DIRECTORIO", "FEX_C"]
+
+
+def test_normalize_shape_a_renames_fex_variants() -> None:
+    """FEX_C_XXXX year-suffixed variants must be renamed to FEX_C."""
+    from pulso._utils.columns import _normalize_dane_columns
+
+    for original in ("FEX_C_2011", "FEX_C_2018", "fex_c_2011", "Fex_c_2011"):
+        df = _make_df(**{original: [1.0]})
+        result = _normalize_dane_columns(df)
+        assert "FEX_C" in result.columns, f"Expected FEX_C after normalizing {original!r}"
+        assert original not in result.columns
+
+
+def test_normalize_shape_a_fex_c_idempotent() -> None:
+    """FEX_C already canonical must stay unchanged."""
+    from pulso._utils.columns import _normalize_dane_columns
+
+    df = _make_df(FEX_C=[5.0], DIRECTORIO=[1])
+    result = _normalize_dane_columns(df)
+    assert "FEX_C" in result.columns
+    assert result["FEX_C"].iloc[0] == 5.0
+
+
+def test_normalize_shape_a_warns_on_multiple_fex() -> None:
+    """If DF has both FEX_C and FEX_C_2011, a UserWarning must be raised."""
+    from pulso._utils.columns import _normalize_dane_columns
+
+    df = _make_df(FEX_C=[1.0], FEX_C_2011=[2.0], DIRECTORIO=[10])
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = _normalize_dane_columns(df)
+
+    assert any(issubclass(w.category, UserWarning) for w in caught), (
+        "Expected a UserWarning when multiple FEX_C-pattern columns are present"
+    )
+    assert "FEX_C" in result.columns
+    assert "FEX_C_2011" not in result.columns
+
+
+def test_normalize_shape_a_preserves_data() -> None:
+    """Data values must not change — only column names."""
+    from pulso._utils.columns import _normalize_dane_columns
+
+    df = _make_df(directorio=[42], secuencia_p=[7], fex_c_2011=[1234.5])
+    result = _normalize_dane_columns(df)
+    assert result["DIRECTORIO"].iloc[0] == 42
+    assert result["SECUENCIA_P"].iloc[0] == 7
+    assert result["FEX_C"].iloc[0] == pytest.approx(1234.5)


### PR DESCRIPTION
Closes the latent parser bug discovered during Phase 3.5 (issue #42).

## Cambios

- **Nuevo `pulso/_utils/columns.py`**: función `_normalize_dane_columns(df)` — extrae el patrón uppercase + rename `FEX_C_XXXX → FEX_C` que estaba duplicado en `empalme.py`. Cubre `FEX_C_2011`, `FEX_C_2018`, y cualquier variante futura con sufijo de año.
- **`parse_shape_a_module()`**: aplica `_normalize_dane_columns()` después de leer y concatenar Cabecera + Resto CSVs. Esto convierte `Hogar → HOGAR`, `Area → AREA`, `Fex_c_2011 → FEX_C`, etc.
- **`empalme._normalize_empalme_columns()`**: ahora delega a `_normalize_dane_columns()`, eliminando la lógica duplicada.
- **5 unit tests** en `tests/unit/test_parser_shape_a_normalization.py` — uppercase, rename de variantes, idempotencia, warn con duplicados, preservación de datos.
- **2 integration tests** en `tests/integration/test_load_merged_2015_06.py` — validan que `load_merged(2015, 6)` completa sin `MergeError` y que las columnas raw son todas uppercase post-load.

## Orden de merge requerido

**REQUIERE PR #46 (Curator, `variable_map.json`) MERGED PRIMERO.**

Si este PR se mergea antes que #46, los integration tests fallarán porque `variable_map.json` seguirá buscando `source_variable: "fex_c_2011"` en un DataFrame que ya tiene `FEX_C` como columna.

## Test results (pre-merge)

- Unit suite: 185 passed, 1 skipped (5 nuevos: `test_parser_shape_a_normalization.py`)
- Integration: pendiente confirmación con datos reales (requiere `--run-integration`)

Closes #42. Cierra Phase 4 Line A. Habilita release candidate v1.0.0-rc1.