### PR TITLE
fix(parser): CLASE duplication + post-uppercase collision detection

### DIFF
--- a/pulso/_core/parser.py
+++ b/pulso/_core/parser.py
@@ -206,18 +206,17 @@ def parse_shape_a_module(
         if cab_name:
             with zf.open(cab_name) as fh:
                 raw = fh.read()
-            df_cab: pd.DataFrame = _read_csv_with_fallback(raw, epoch)
+            df_cab: pd.DataFrame = _normalize_dane_columns(_read_csv_with_fallback(raw, epoch))
             df_cab["CLASE"] = 1
             dfs.append(df_cab)
         if resto_name:
             with zf.open(resto_name) as fh:
                 raw = fh.read()
-            df_resto: pd.DataFrame = _read_csv_with_fallback(raw, epoch)
+            df_resto: pd.DataFrame = _normalize_dane_columns(_read_csv_with_fallback(raw, epoch))
             df_resto["CLASE"] = 2
             dfs.append(df_resto)
 
-    result = dfs[0] if len(dfs) == 1 else pd.concat(dfs, axis=0, ignore_index=True)
-    return _normalize_dane_columns(result)
+    return dfs[0] if len(dfs) == 1 else pd.concat(dfs, axis=0, ignore_index=True)
 
 
 def _parse_csv(

--- a/pulso/_utils/columns.py
+++ b/pulso/_utils/columns.py
@@ -30,6 +30,16 @@ def _normalize_dane_columns(df: pd.DataFrame) -> pd.DataFrame:
     df = df.copy()
     df.columns = df.columns.str.upper()
 
+    # Detect columns that collided after uppercasing (e.g. 'Clase' + 'CLASE').
+    if df.columns.duplicated().any():
+        dupes = [c for c in df.columns if (df.columns == c).sum() > 1]
+        warnings.warn(
+            f"Columns {dupes} collide post-uppercase. Keeping first occurrence.",
+            UserWarning,
+            stacklevel=3,
+        )
+        df = df.loc[:, ~df.columns.duplicated()]
+
     fex_matches = [c for c in df.columns if _FEX_C_PATTERN.match(c)]
 
     if len(fex_matches) > 1:

--- a/tests/unit/test_parser_shape_a_normalization.py
+++ b/tests/unit/test_parser_shape_a_normalization.py
@@ -62,6 +62,17 @@ def test_normalize_shape_a_warns_on_multiple_fex() -> None:
     assert "FEX_C_2011" not in result.columns
 
 
+def test_normalize_dane_columns_drops_duplicates_with_warning() -> None:
+    """Columns that collide after uppercasing must warn and keep first occurrence."""
+    from pulso._utils.columns import _normalize_dane_columns
+
+    df = pd.DataFrame({"Clase": [1, 2], "CLASE": [3, 4]})
+    with pytest.warns(UserWarning, match="collide"):
+        result = _normalize_dane_columns(df)
+    assert list(result.columns) == ["CLASE"]
+    assert result["CLASE"].tolist() == [1, 2]  # first wins
+
+
 def test_normalize_shape_a_preserves_data() -> None:
     """Data values must not change — only column names."""
     from pulso._utils.columns import _normalize_dane_columns


### PR DESCRIPTION
Cierra los 2 fallos integration que aparecieron tras Phase 4 Línea A (PRs #46 + #47).

## Root cause

`parse_shape_a_module` asignaba `df["CLASE"] = N` sobre el DataFrame crudo, **antes** de normalizar columnas. Si el CSV DANE de ese mes traía `'Clase'` (mixed-case), pandas creaba dos columnas distintas: `'Clase'` (original) y `'CLASE'` (sintético). Luego `_normalize_dane_columns` las convertía ambas a `'CLASE'`, dejando una columna duplicada que rompía el merge posterior.

## Fixes

**1. `parse_shape_a_module` (`pulso/_core/parser.py`)**

Normaliza cada DataFrame **antes** de añadir el CLASE sintético:
```python
# Antes (broken)
df_cab = _read_csv_with_fallback(raw, epoch)
df_cab["CLASE"] = 1          # 'Clase' (CSV) y 'CLASE' (sintético) coexisten
...
return _normalize_dane_columns(result)   # duplica CLASE

# Después (correcto)
df_cab = _normalize_dane_columns(_read_csv_with_fallback(raw, epoch))
df_cab["CLASE"] = 1          # 'Clase' → 'CLASE' ya hecho; sobrescribe in-place
...
return result                # sin normalize al final (ya hecho por parte)
```

**2. `_normalize_dane_columns` (`pulso/_utils/columns.py`)**

Detecta columnas que colisionan post-uppercase, emite `UserWarning` con detalle, y dropea conservando primera occurrence. Convierte un bug silencioso en error detectable.

**3. Test unitario nuevo**

`test_normalize_dane_columns_drops_duplicates_with_warning`: verifica que `DataFrame({'Clase': [1,2], 'CLASE': [3,4]})` → `{'CLASE': [1,2]}` con `UserWarning("collide")`.

## Test results post-fix

- Unit: **186 passed**, 1 skipped
- Integration (`--run-integration`): **463 passed**, 0 failed
- `test_load_merged_2015_06`: **2 passed** (ambos que antes fallaban)

Cierra el bloqueador que impedía v1.0.0-rc1.