### PR TITLE
build: clean wheel packaging + version bump to 1.0.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pulso"
-version = "0.0.1"
+version = "1.0.0rc1"
 description = "Python library to load GEIH microdata from Colombia's DANE"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["dane", "geih", "colombia", "microdata", "labor-force-survey", "encuesta-hogares", "pulso"]
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
@@ -76,11 +76,6 @@ pulso-add-month = "scripts.add_month:main"
 [tool.hatch.build.targets.wheel]
 packages = ["pulso"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"pulso/data/sources.json" = "pulso/data/sources.json"
-"pulso/data/variable_map.json" = "pulso/data/variable_map.json"
-"pulso/data/epochs.json" = "pulso/data/epochs.json"
-"pulso/data/schemas" = "pulso/data/schemas"
 
 # ─── Testing ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes packaging warnings discovered during pre-PyPI smoke test.

## Changes
1. Remove `[tool.hatch.build.targets.wheel.force-include]` block — these files are already included via `packages = ['pulso']`. The block caused 4 schema files to be duplicated in the wheel ZIP, triggering `UserWarning: Duplicate name` during build.
2. Bump version `0.0.1` → `1.0.0rc1` to match the existing tag `v1.0.0-rc1`.
3. Bump classifier `Development Status :: 2 - Pre-Alpha` → `4 - Beta` to reflect release candidate status.

## Validation
- Build runs without UserWarning
- Wheel contains 9 data files (was 13 with duplicates)
- pip install succeeds in clean venv
- Smoke test passes (load_empalme + apply_smoothing exposed)

## Next steps post-merge
- TestPyPI upload (validation)
- PyPI release v1.0.0rc1