### PR TITLE
docs: README en orden Español→Inglés + sync __version__ + créditos del autor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,217 +10,7 @@
 
 ---
 
-[**English**](#english) | [**Español**](#español)
-
----
-
-<a id="english"></a>
-
-## 🇬🇧 English
-
-### What is pulso?
-
-`pulso` is a Python library that gives you single-line access to Colombia's **Gran Encuesta Integrada de Hogares (GEIH)** — the monthly household survey published by DANE, the national statistics office. No manual downloads, no ZIP wrangling, no encoding headaches.
-
-Three things it does:
-
-- **Download** — fetches the official ZIP from DANE's microdata portal, caches it locally, verifies SHA-256.
-- **Parse** — handles three structural formats (Shape A: Cabecera/Resto split for 2006–2021; Shape B: unified nationwide file for 2022–present; Shape C: Empalme annual ZIPs).
-- **Harmonize** — maps raw DANE column codes (`P6020`, `FEX_C18`, …) to named canonical variables (`sexo`, `peso_expansion`, …) consistently across methodological epochs.
-
-```python
-import pulso
-
-# Load one module, one month
-df = pulso.load(year=2024, month=6, module="ocupados")
-
-# Time series across years
-df = pulso.load(year=range(2018, 2025), month=6, module="ocupados")
-
-# Multi-module merge
-df = pulso.load_merged(year=2024, month=6,
-                       modules=["ocupados", "caracteristicas_generales"])
-
-# Epoch-smoothed load using GEIH Empalme (2010–2019)
-df = pulso.load_merged(year=2015, month=6, apply_smoothing=True)
-
-# Load the full Empalme annual dataset
-df_empalme = pulso.load_empalme(year=2015, harmonize=True)
-```
-
-### Coverage
-
-| Attribute | Detail |
-|-----------|--------|
-| **Period** | 2006-01 to present (latest month published by DANE) |
-| **Geography** | National: cabecera (urban) + resto (rural), 23 cities and metro areas |
-| **Modules** | `caracteristicas_generales`, `ocupados`, `desocupados`, `inactivos`, `vivienda_hogares`, `otros_ingresos`, `migracion`\*, `otras_formas_trabajo`\* |
-| **Validated months** | 2007-12, 2015-06, 2021-12, 2022-01, 2024-06 (end-to-end with real DANE data) |
-| **Registry entries** | ~230 monthly entries (2006-01 → 2026-02) |
-
-\* Available only in `geih_2021_present` epoch (2022-01 onward).
-
-> **Out of scope:** The Encuesta Continua de Hogares (ECH, 2000–2005) is not included. ECH uses a different sampling frame, definitions, and coverage; merging it with GEIH under a single harmonized API would be misleading.
-
-### Methodological epochs
-
-DANE changed the GEIH methodology significantly in 2022. `pulso` models this as two epochs:
-
-| Epoch key | Period | Sampling frame | Weight variable |
-|-----------|--------|----------------|-----------------|
-| `geih_2006_2020` | 2006-01 → 2021-12 | 2005 census | `fex_c_2011` |
-| `geih_2021_present` | **2022-01** → present | 2018 census (post-ILO) | `FEX_C18` |
-
-> ⚠️ The epoch boundary is **2022-01**, not 2021. Estimates that span this boundary carry a documented comparability warning.
-
-### Smoothing across the epoch boundary (Empalme)
-
-DANE publishes the **GEIH Empalme** series (2010–2020) — annual ZIPs that re-estimate monthly microdata under the unified 2005-census framework. This is the standard tool for constructing consistent multi-year time series before the 2022 redesign.
-
-`pulso` exposes two ways to use it:
-
-```python
-# Transparent swap: load 2015-06 using Empalme data instead of raw GEIH
-df = pulso.load_merged(year=2015, month=6, harmonize=True, apply_smoothing=True)
-
-# Direct access: all 12 months of Empalme 2015 stacked
-df = pulso.load_empalme(year=2015, module="ocupados", harmonize=True)
-```
-
-Empalme ZIPs are cached separately under `empalme/{year}.zip`.  
-Year 2020 exists in DANE's catalog but the ZIP has not been published; `load_empalme(2020)` raises `DataNotAvailableError`.
-
-### Installation
-
-```bash
-pip install pulso
-```
-
-### Quickstart
-
-```python
-import pulso
-
-# 1. See what's available
-available = pulso.list_available()          # all months
-available_2024 = pulso.list_available(year=2024)
-
-# 2. List canonical modules
-pulso.list_modules()
-
-# 3. Load a single module
-df = pulso.load(year=2024, month=6, module="caracteristicas_generales", area="total")
-
-# 4. Multi-module merge with harmonization
-df = pulso.load_merged(
-    year=2024, month=6,
-    modules=["ocupados", "caracteristicas_generales"],
-    harmonize=True,
-)
-
-# 5. Apply expansion factors (conscious choice — not automatic)
-df_expanded = pulso.expand(df, weight="peso_expansion")
-```
-
-### Public API
-
-| Function | Status | Description |
-|----------|--------|-------------|
-| `load(year, month, module, ...)` | ✅ stable | Load one module for one or more periods |
-| `load_merged(year, month, modules, ..., apply_smoothing)` | ✅ stable | Load + merge multiple modules; optional Empalme swap |
-| `load_empalme(year, module, area, harmonize)` | ✅ stable | Load GEIH Empalme annual dataset (2010–2019) |
-| `expand(df, weight)` | ✅ stable | Apply expansion factors row-by-row |
-| `list_available(year)` | ✅ stable | DataFrame of available (year, month) pairs |
-| `list_modules()` | ✅ stable | DataFrame of canonical module definitions |
-| `cache_info()` | ✅ stable | Cache size and layout summary |
-| `cache_clear(level)` | ✅ stable | Clear raw / parsed / harmonized / all |
-| `cache_path()` | ✅ stable | Absolute path to cache root |
-| `data_version()` | ✅ stable | Registry data version (e.g. `"2026.04"`) |
-| `list_variables()` | 🚧 planned | List canonical harmonized variables |
-| `describe_variable(name)` | 🚧 planned | Variable definition + comparability notes |
-| `describe_harmonization(variable)` | 🚧 planned | Per-epoch mapping details |
-| `describe(module, year)` | 🚧 planned | Module metadata + epoch info |
-
-### Local cache
-
-Downloaded microdata is cached under the platform default directory (managed by `platformdirs`):
-
-| OS | Default cache path |
-|----|--------------------|
-| Linux / macOS | `~/.cache/pulso/` |
-| Windows | `%LOCALAPPDATA%\pulso\pulso\Cache\` |
-
-Layout:
-
-```
-<cache_root>/
-├── raw/{year}/{month:02d}/{checksum_short}.zip    # original DANE ZIP
-├── empalme/{year}.zip                             # Empalme annual ZIPs
-├── parsed/{year}/{month:02d}/{module}.parquet     # post-parser (future)
-└── harmonized/{year}/{month:02d}/{module}.parquet # post-harmonize (future)
-```
-
-Inspect and manage:
-
-```python
-pulso.cache_info()                    # size, file count, by level
-pulso.cache_path()                    # absolute path
-pulso.cache_clear(level="raw")        # clear one level
-pulso.cache_clear(level="all")        # clear everything
-```
-
-### Important caveats
-
-Before using results in a publication, please read [`docs/caveats.md`](docs/caveats.md):
-
-1. **Harmonization does not remove real DANE discontinuities.** The 2022 redesign changed definitions, sampling frame, and geographic coverage. Treat cross-epoch comparisons (especially pre/post 2022) with care.
-2. **`expand()` ignores sampling design.** Summing expanded weights with `groupby().sum()` yields point estimates but no correct standard errors. For rigorous inference, use a survey analysis package (e.g. `samplics`).
-3. **Not an official DANE product.** For official use, refer to DANE's microdata portal: <https://microdatos.dane.gov.co/>
-
-### Why "pulso" and not "geih"
-
-`pulso` is the package name; `GEIH` is the survey it loads today. The distinction matters: if future versions add other DANE surveys (e.g. ENPH, ECV), they can live in sub-namespaces (`pulso.enph`, `pulso.ecv`) without breaking the root namespace. For now, `pulso.load(...)` always loads GEIH.
-
-### Status
-
-Active development — not yet on PyPI. Current development tag: `v0.4.0-phase35-smoothing`.
-
-| Phase | Description | Status |
-|-------|-------------|--------|
-| 0 | Scaffolding | ✅ |
-| 1 | Vertical slice — single month | ✅ |
-| 2 | Harmonizer and merger | ✅ |
-| 3 | Full GEIH coverage (2006–present) | ✅ |
-| 3.5 | Empalme loader + smoothing | ✅ |
-| 4 | Technical debt + variable introspection | 🚧 |
-| 5 | PyPI release | ⏳ |
-
-See [`CHANGELOG.md`](CHANGELOG.md) for details.
-
-### Contributing
-
-See [`CONTRIBUTING.md`](CONTRIBUTING.md). Especially welcome:
-
-- Reporting a month that fails to load
-- Proposing a new harmonized variable
-- Finding a discrepancy with official DANE statistics
-
-### Citation
-
-If you use this package in a publication, cite DANE as the primary data source, and optionally this package as the tool:
-
-```text
-DANE (2024). Gran Encuesta Integrada de Hogares (GEIH).
-  Departamento Administrativo Nacional de Estadística.
-  https://microdatos.dane.gov.co/
-
-pulso (2026). Python library to load GEIH microdata from Colombia's DANE.
-  https://github.com/Stebandido77/pulso
-```
-
-### License
-
-Code is MIT-licensed (see [`LICENSE`](LICENSE)). Downloaded microdata belongs to DANE and is governed by the terms of use of the microdata portal.
+[**Español**](#español) | [**English**](#english)
 
 ---
 
@@ -278,7 +68,7 @@ El DANE cambió significativamente la metodología de la GEIH en 2022. `pulso` m
 
 | Clave de época | Período | Marco muestral | Variable de expansión |
 |----------------|---------|----------------|----------------------|
-| `geih_2006_2020` | 2006-01 → 2021-12 | Censo 2005 | `fex_c_2011` |
+| `geih_2006_2020` | 2006-01 → 2021-12 | Censo 2005 | `FEX_C` |
 | `geih_2021_present` | **2022-01** → presente | Censo 2018 (post-OIT) | `FEX_C18` |
 
 > ⚠️ El cambio de época está en **2022-01**, no en 2021. Las estimaciones que cruzan este límite llevan una advertencia de comparabilidad documentada.
@@ -393,7 +183,7 @@ Antes de usar los resultados en una publicación, lee [`docs/caveats.md`](docs/c
 
 ### Estado del proyecto
 
-Desarrollo activo — aún no está en PyPI. Tag de desarrollo actual: `v0.4.0-phase35-smoothing`.
+Versión actual: **v1.0.0-rc1** (release candidate). Disponible en [TestPyPI](https://test.pypi.org/project/pulso/).
 
 | Fase | Descripción | Estado |
 |------|-------------|--------|
@@ -402,8 +192,8 @@ Desarrollo activo — aún no está en PyPI. Tag de desarrollo actual: `v0.4.0-p
 | 2 | Harmonizer y merger | ✅ |
 | 3 | Cobertura GEIH completa (2006–presente) | ✅ |
 | 3.5 | Empalme loader + apply_smoothing | ✅ |
-| 4 | Deuda técnica + introspección de variables | 🚧 |
-| 5 | Release en PyPI | ⏳ |
+| 4 | Deuda técnica + normalización Shape A | ✅ |
+| 5 | Release en PyPI | 🚧 |
 
 Ver [`CHANGELOG.md`](CHANGELOG.md) para más detalles.
 
@@ -424,10 +214,252 @@ DANE (2024). Gran Encuesta Integrada de Hogares (GEIH).
   Departamento Administrativo Nacional de Estadística.
   https://microdatos.dane.gov.co/
 
-pulso (2026). Python library to load GEIH microdata from Colombia's DANE.
+Labastidas, E. (2026). pulso: Python library to load GEIH microdata from Colombia's DANE.
   https://github.com/Stebandido77/pulso
 ```
 
 ### Licencia
 
 El código está bajo licencia MIT (ver [`LICENSE`](LICENSE)). Los microdatos descargados son propiedad del DANE y se rigen por los términos de uso del portal de microdatos.
+
+---
+
+<a id="english"></a>
+
+## 🇬🇧 English
+
+### What is pulso?
+
+`pulso` is a Python library that gives you single-line access to Colombia's **Gran Encuesta Integrada de Hogares (GEIH)** — the monthly household survey published by DANE, the national statistics office. No manual downloads, no ZIP wrangling, no encoding headaches.
+
+Three things it does:
+
+- **Download** — fetches the official ZIP from DANE's microdata portal, caches it locally, verifies SHA-256.
+- **Parse** — handles three structural formats (Shape A: Cabecera/Resto split for 2006–2021; Shape B: unified nationwide file for 2022–present; Shape C: Empalme annual ZIPs).
+- **Harmonize** — maps raw DANE column codes (`P6020`, `FEX_C18`, …) to named canonical variables (`sexo`, `peso_expansion`, …) consistently across methodological epochs.
+
+```python
+import pulso
+
+# Load one module, one month
+df = pulso.load(year=2024, month=6, module="ocupados")
+
+# Time series across years
+df = pulso.load(year=range(2018, 2025), month=6, module="ocupados")
+
+# Multi-module merge
+df = pulso.load_merged(year=2024, month=6,
+                       modules=["ocupados", "caracteristicas_generales"])
+
+# Epoch-smoothed load using GEIH Empalme (2010–2019)
+df = pulso.load_merged(year=2015, month=6, apply_smoothing=True)
+
+# Load the full Empalme annual dataset
+df_empalme = pulso.load_empalme(year=2015, harmonize=True)
+```
+
+### Coverage
+
+| Attribute | Detail |
+|-----------|--------|
+| **Period** | 2006-01 to present (latest month published by DANE) |
+| **Geography** | National: cabecera (urban) + resto (rural), 23 cities and metro areas |
+| **Modules** | `caracteristicas_generales`, `ocupados`, `desocupados`, `inactivos`, `vivienda_hogares`, `otros_ingresos`, `migracion`\*, `otras_formas_trabajo`\* |
+| **Validated months** | 2007-12, 2015-06, 2021-12, 2022-01, 2024-06 (end-to-end with real DANE data) |
+| **Registry entries** | ~230 monthly entries (2006-01 → 2026-02) |
+
+\* Available only in `geih_2021_present` epoch (2022-01 onward).
+
+> **Out of scope:** The Encuesta Continua de Hogares (ECH, 2000–2005) is not included. ECH uses a different sampling frame, definitions, and coverage; merging it with GEIH under a single harmonized API would be misleading.
+
+### Methodological epochs
+
+DANE changed the GEIH methodology significantly in 2022. `pulso` models this as two epochs:
+
+| Epoch key | Period | Sampling frame | Weight variable |
+|-----------|--------|----------------|-----------------|
+| `geih_2006_2020` | 2006-01 → 2021-12 | 2005 census | `FEX_C` |
+| `geih_2021_present` | **2022-01** → present | 2018 census (post-ILO) | `FEX_C18` |
+
+> ⚠️ The epoch boundary is **2022-01**, not 2021. Estimates that span this boundary carry a documented comparability warning.
+
+### Smoothing across the epoch boundary (Empalme)
+
+DANE publishes the **GEIH Empalme** series (2010–2020) — annual ZIPs that re-estimate monthly microdata under the unified 2005-census framework. This is the standard tool for constructing consistent multi-year time series before the 2022 redesign.
+
+`pulso` exposes two ways to use it:
+
+```python
+# Transparent swap: load 2015-06 using Empalme data instead of raw GEIH
+df = pulso.load_merged(year=2015, month=6, harmonize=True, apply_smoothing=True)
+
+# Direct access: all 12 months of Empalme 2015 stacked
+df = pulso.load_empalme(year=2015, module="ocupados", harmonize=True)
+```
+
+Empalme ZIPs are cached separately under `empalme/{year}.zip`.  
+Year 2020 exists in DANE's catalog but the ZIP has not been published; `load_empalme(2020)` raises `DataNotAvailableError`.
+
+### Installation
+
+```bash
+pip install pulso
+```
+
+### Quickstart
+
+```python
+import pulso
+
+# 1. See what's available
+available = pulso.list_available()          # all months
+available_2024 = pulso.list_available(year=2024)
+
+# 2. List canonical modules
+pulso.list_modules()
+
+# 3. Load a single module
+df = pulso.load(year=2024, month=6, module="caracteristicas_generales", area="total")
+
+# 4. Multi-module merge with harmonization
+df = pulso.load_merged(
+    year=2024, month=6,
+    modules=["ocupados", "caracteristicas_generales"],
+    harmonize=True,
+)
+
+# 5. Apply expansion factors (conscious choice — not automatic)
+df_expanded = pulso.expand(df, weight="peso_expansion")
+```
+
+### Public API
+
+| Function | Status | Description |
+|----------|--------|-------------|
+| `load(year, month, module, ...)` | ✅ stable | Load one module for one or more periods |
+| `load_merged(year, month, modules, ..., apply_smoothing)` | ✅ stable | Load + merge multiple modules; optional Empalme swap |
+| `load_empalme(year, module, area, harmonize)` | ✅ stable | Load GEIH Empalme annual dataset (2010–2019) |
+| `expand(df, weight)` | ✅ stable | Apply expansion factors row-by-row |
+| `list_available(year)` | ✅ stable | DataFrame of available (year, month) pairs |
+| `list_modules()` | ✅ stable | DataFrame of canonical module definitions |
+| `cache_info()` | ✅ stable | Cache size and layout summary |
+| `cache_clear(level)` | ✅ stable | Clear raw / parsed / harmonized / all |
+| `cache_path()` | ✅ stable | Absolute path to cache root |
+| `data_version()` | ✅ stable | Registry data version (e.g. `"2026.04"`) |
+| `list_variables()` | 🚧 planned | List canonical harmonized variables |
+| `describe_variable(name)` | 🚧 planned | Variable definition + comparability notes |
+| `describe_harmonization(variable)` | 🚧 planned | Per-epoch mapping details |
+| `describe(module, year)` | 🚧 planned | Module metadata + epoch info |
+
+### Local cache
+
+Downloaded microdata is cached under the platform default directory (managed by `platformdirs`):
+
+| OS | Default cache path |
+|----|--------------------|
+| Linux / macOS | `~/.cache/pulso/` |
+| Windows | `%LOCALAPPDATA%\pulso\pulso\Cache\` |
+
+Layout:
+
+```
+<cache_root>/
+├── raw/{year}/{month:02d}/{checksum_short}.zip    # original DANE ZIP
+├── empalme/{year}.zip                             # Empalme annual ZIPs
+├── parsed/{year}/{month:02d}/{module}.parquet     # post-parser (future)
+└── harmonized/{year}/{month:02d}/{module}.parquet # post-harmonize (future)
+```
+
+Inspect and manage:
+
+```python
+pulso.cache_info()                    # size, file count, by level
+pulso.cache_path()                    # absolute path
+pulso.cache_clear(level="raw")        # clear one level
+pulso.cache_clear(level="all")        # clear everything
+```
+
+### Important caveats
+
+Before using results in a publication, please read [`docs/caveats.md`](docs/caveats.md):
+
+1. **Harmonization does not remove real DANE discontinuities.** The 2022 redesign changed definitions, sampling frame, and geographic coverage. Treat cross-epoch comparisons (especially pre/post 2022) with care.
+2. **`expand()` ignores sampling design.** Summing expanded weights with `groupby().sum()` yields point estimates but no correct standard errors. For rigorous inference, use a survey analysis package (e.g. `samplics`).
+3. **Not an official DANE product.** For official use, refer to DANE's microdata portal: <https://microdatos.dane.gov.co/>
+
+### Why "pulso" and not "geih"
+
+`pulso` is the package name; `GEIH` is the survey it loads today. The distinction matters: if future versions add other DANE surveys (e.g. ENPH, ECV), they can live in sub-namespaces (`pulso.enph`, `pulso.ecv`) without breaking the root namespace. For now, `pulso.load(...)` always loads GEIH.
+
+### Status
+
+Current version: **v1.0.0-rc1** (release candidate). Available on [TestPyPI](https://test.pypi.org/project/pulso/).
+
+| Phase | Description | Status |
+|-------|-------------|--------|
+| 0 | Scaffolding | ✅ |
+| 1 | Vertical slice — single month | ✅ |
+| 2 | Harmonizer and merger | ✅ |
+| 3 | Full GEIH coverage (2006–present) | ✅ |
+| 3.5 | Empalme loader + smoothing | ✅ |
+| 4 | Technical debt + Shape A normalization | ✅ |
+| 5 | PyPI release | 🚧 |
+
+See [`CHANGELOG.md`](CHANGELOG.md) for details.
+
+### Contributing
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md). Especially welcome:
+
+- Reporting a month that fails to load
+- Proposing a new harmonized variable
+- Finding a discrepancy with official DANE statistics
+
+### Citation
+
+If you use this package in a publication, cite DANE as the primary data source, and optionally this package as the tool:
+
+```text
+DANE (2024). Gran Encuesta Integrada de Hogares (GEIH).
+  Departamento Administrativo Nacional de Estadística.
+  https://microdatos.dane.gov.co/
+
+Labastidas, E. (2026). pulso: Python library to load GEIH microdata from Colombia's DANE.
+  https://github.com/Stebandido77/pulso
+```
+
+### License
+
+Code is MIT-licensed (see [`LICENSE`](LICENSE)). Downloaded microdata belongs to DANE and is governed by the terms of use of the microdata portal.
+
+---
+
+## Créditos
+
+`pulso` fue creado por **Esteban Labastidas** ([@Stebandido77](https://github.com/Stebandido77)).
+
+El paquete fue construido usando un sistema multi-agente de codificación basado en Claude (Anthropic), diseñado y dirigido por el autor:
+
+- **Architect** (Claude Opus, chat): diseño arquitectónico, RFCs, revisión y coordinación de PRs
+- **Builder** (Claude Code): implementación de código en `pulso/_core/`
+- **Curator** (Claude Code): gestión del catálogo de datos en `pulso/data/`
+
+La arquitectura del sistema multi-agente, las decisiones técnicas y el diseño del paquete son obra del autor. Los agentes ejecutan implementación bajo supervisión y dirección humana directa.
+
+Ver [`docs/architecture.md`](docs/architecture.md) sección 6 para detalles del modelo de construcción.
+
+---
+
+## Credits
+
+`pulso` was created by **Esteban Labastidas** ([@Stebandido77](https://github.com/Stebandido77)).
+
+The package was built using a Claude-based (Anthropic) multi-agent coding system, designed and directed by the author:
+
+- **Architect** (Claude Opus, chat): architectural design, RFCs, PR review and coordination
+- **Builder** (Claude Code): code implementation in `pulso/_core/`
+- **Curator** (Claude Code): data catalog management in `pulso/data/`
+
+The multi-agent system architecture, technical decisions, and package design are the author's work. The agents execute implementation under direct human supervision and direction.
+
+See [`docs/architecture.md`](docs/architecture.md) section 6 for build model details.

--- a/pulso/__init__.py
+++ b/pulso/__init__.py
@@ -35,7 +35,7 @@ from pulso._core.expander import expand
 from pulso._core.loader import load, load_merged
 from pulso._utils.cache import cache_clear, cache_info, cache_path
 
-__version__ = "0.0.1"
+__version__ = "1.0.0rc1"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
Tres cambios coordinados para el README y la versión del paquete.

## Cambios

**1. Orden de idiomas invertido (Español primero)**
El README anterior tenía English primero. Ahora el toggle es `[Español] | [English]` y la sección española aparece inmediatamente después del header con badges. Todo el contenido existente se preserva sin modificaciones de fondo.

**2. Sección de Créditos bilingüe (nueva, al final)**
Documenta claramente que `pulso` fue creado por Esteban Labastidas (@Stebandido77). Describe el sistema multi-agente Claude (Architect / Builder / Curator) como herramientas de implementación bajo supervisión y dirección humana directa. El énfasis es que la autoría del diseño, las decisiones técnicas y la arquitectura son del autor humano.

**3. Sync de `__version__`**
`pulso/__init__.py` línea 38: `"0.0.1"` → `"1.0.0rc1"`. La versión hardcodeada no matcheaba `pyproject.toml` ni el tag `v1.0.0-rc1` ya en TestPyPI.

**4. Actualizaciones menores de contenido**
- Sección Estado: actualizada a v1.0.0-rc1 como release candidate actual (antes decía "no está en PyPI, tag v0.4.0-phase35-smoothing").
- Fase 4 marcada como ✅ (deuda técnica + normalización Shape A cerrada con PRs #46–#48).
- Citación: añade el nombre del autor (`Labastidas, E.`) en ambos idiomas.
- Tabla de épocas: `fex_c_2011` → `FEX_C` (consistente con PR #46).

## Test results

- `python -c "import pulso; print(pulso.__version__)"` → `1.0.0rc1`
- `pytest -q` → 186 passed, 277 skipped