### PR TITLE
fix(ci): add sync_data_to_r.R script (unblocks R CMD check)

### DIFF
--- a/scripts/sync_data_to_r.R
+++ b/scripts/sync_data_to_r.R
@@ -1,0 +1,81 @@
+#!/usr/bin/env Rscript
+# scripts/sync_data_to_r.R
+#
+# Sync canonical data files from data/ (monorepo root) to r/inst/extdata/
+# so the R package bundles them when installed.
+#
+# Used by .github/workflows/r-ci.yml before R CMD check.
+# Can also be run manually during development:
+#   Rscript scripts/sync_data_to_r.R
+#
+# CRAN compliance:
+# - 4 small JSONs (~135 KB total) bundled into the package
+# - dane_codebook.json (6.7 MB) explicitly EXCLUDED (lazy-downloaded at runtime)
+
+if (!requireNamespace("fs", quietly = TRUE)) {
+  stop("Package 'fs' is required. Install with: install.packages('fs')")
+}
+
+# Files to sync (CRAN-bundleable, total ~135 KB)
+sync_files <- c(
+  "sources.json",
+  "variable_map.json",
+  "variable_module_map.json",
+  "epochs.json",
+  "codebook_release.json"
+)
+
+# Files explicitly NOT synced (exceed CRAN 5 MB package size limit)
+excluded <- c("dane_codebook.json")
+
+source_dir <- "data"
+target_dir <- "r/inst/extdata"
+
+# Validate paths
+if (!fs::dir_exists(source_dir)) {
+  stop(sprintf("Source directory missing: %s (run from monorepo root)",
+               source_dir))
+}
+
+# Ensure target exists
+fs::dir_create(target_dir, recurse = TRUE)
+
+# Sync each file
+synced <- character(0)
+missing <- character(0)
+
+for (f in sync_files) {
+  src <- fs::path(source_dir, f)
+  dst <- fs::path(target_dir, f)
+
+  if (!fs::file_exists(src)) {
+    missing <- c(missing, f)
+    next
+  }
+
+  fs::file_copy(src, dst, overwrite = TRUE)
+  synced <- c(synced, f)
+  cat(sprintf("Copied: %s -> %s\n", src, dst))
+}
+
+# Warn on missing source files (not fatal, may be expected during dev)
+if (length(missing) > 0) {
+  warning(sprintf("Source files missing (skipped): %s",
+                  paste(missing, collapse = ", ")))
+}
+
+# Verify excluded files are NOT in target
+for (f in excluded) {
+  dst <- fs::path(target_dir, f)
+  if (fs::file_exists(dst)) {
+    stop(sprintf(
+      "Excluded file present in r/inst/extdata/: %s (must NOT be bundled to comply with CRAN size limit)",
+      f
+    ))
+  }
+}
+
+cat(sprintf("\nSync complete. %d files copied to %s.\n",
+            length(synced), target_dir))
+cat(sprintf("Excluded (lazy-downloaded at runtime): %s\n",
+            paste(excluded, collapse = ", ")))


### PR DESCRIPTION
## Summary

Adds `scripts/sync_data_to_r.R` — the script that `.github/workflows/r-ci.yml` line 64 has been calling since Mini-4A, but which never existed in the repo.

## Why

The workflow step "Sync canonical data into r/inst/extdata/" runs `Rscript scripts/sync_data_to_r.R`. With the script missing, that step has been failing on every R CI run, which means the next step (`r-lib/actions/check-r-package@v2`) has been **skipped on every platform across PRs #56 and #57**.

PR #56 (Mini-4B-1) was merged with all 4 R CMD check matrix jobs red:
```
R CMD check (ubuntu-latest R-release): FAILURE
R CMD check (ubuntu-latest R-devel):   FAILURE
R CMD check (macos-latest R-release):  FAILURE
R CMD check (windows-latest R-release): FAILURE
lintr (R release):                     SUCCESS
```

PR #57 (Mini-4B-2) inherited the same failures. Same root cause both times — the missing script — not Mini-4B-2's metadata code.

This was flagged as an Agente 6 follow-up in `docs/internal/r-port/05_r_api_design_final.md` §5.4 and again in PR #56's description. Pulling it forward as a small dedicated PR so we can finally see whether R CMD check actually passes on the merged code.

## What the script does

- Copies 4 small canonical JSONs (`sources.json`, `variable_map.json`, `variable_module_map.json`, `epochs.json`) plus `codebook_release.json` from `data/` to `r/inst/extdata/`. Total under ~135 KB — well within CRAN's 5 MB package size limit.
- **Explicitly errors** if `r/inst/extdata/dane_codebook.json` exists (6.7 MB, exceeds CRAN limit). Defense-in-depth against accidental bundling. Per the design in `05_r_api_design_final.md` §5, the codebook is lazy-downloaded at runtime to `tools::R_user_dir(\"pulso\", \"cache\")` rather than bundled.
- Missing source files emit `warning()` (non-fatal) and the script continues. Existing target files are preserved when the source is absent.

## Behavior on the current repo state

`data/` has 4 of the 5 listed sources; `data/codebook_release.json` does **not** yet exist (only `r/inst/extdata/codebook_release.json` from Mini-4B-1). The script will:

1. Copy 4 files: `sources.json`, `variable_map.json`, `variable_module_map.json`, `epochs.json` ✓
2. Skip `codebook_release.json`, emit a warning to the log ⚠ (non-fatal)
3. Verify `dane_codebook.json` is absent from the target ✓
4. Exit 0

CI step succeeds, log shows the warning. A small follow-up could move `r/inst/extdata/codebook_release.json` to `data/codebook_release.json` to silence the warning — out of scope here.

## What this PR does NOT include

- **No lintr fixes.** Lintr passed on PR #57 (warnings only). The 4 line-length annotations in `r/R/composer.R` will be addressed in a follow-up commit on PR #57's branch — once this fix lands, R CMD check actually runs there for the first time, and we can react to real findings instead of misdiagnosing a skipped step.
- **No changes to `python/`, `r/R/`, `r/inst/extdata/`, `r/DESCRIPTION`, `r/NAMESPACE`, or any Mini-4A / 4B-1 / 4B-2 files.** Single-file PR by design.
- **No touch of the `feat/r-port-agent-4b-2` branch.** PR #57 stays exactly as it was.

## Expected sequence after merge

1. Merge this PR to `feat/r-port` → `scripts/sync_data_to_r.R` is in place.
2. Add a follow-up commit to PR #57's branch with the 4 line wraps in `composer.R`. CI re-runs.
3. R CMD check actually executes for the first time on `feat/r-port-agent-4b-2` (and any future R PRs).
4. If green → merge PR #57. If red → real diagnosis from real R CMD check output, not a skipped step.

## Test plan

- [ ] Review the script — does the `excluded` defense-in-depth check make sense, or should it just `unlink()` instead of erroring?
- [ ] Decide whether `data/codebook_release.json` should also be added in this PR (would silence the warning) or left for a separate small commit.
- [ ] Approve so we can finally see CI reality on the R port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)