### PR TITLE
fix(r): resolve R CMD check NOTEs + restore sync_data_to_r.R

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -20,13 +20,13 @@ Imports:
     httr2 (>= 1.0.0),
     jsonlite (>= 1.8.0),
     tibble (>= 3.2.0),
-    haven (>= 2.5.0),
-    vctrs (>= 0.6.0),
     rlang (>= 1.1.0),
     cli (>= 3.6.0),
     fs (>= 1.6.0),
     digest (>= 0.6.0)
 Suggests:
+    haven (>= 2.5.0),
+    vctrs (>= 0.6.0),
     dplyr,
     tidyr,
     testthat (>= 3.2.0),

--- a/r/LICENSE
+++ b/r/LICENSE
@@ -1,21 +1,2 @@
-MIT License
-
-Copyright (c) 2026 pulso contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+YEAR: 2026
+COPYRIGHT HOLDER: Esteban Labastidas

--- a/r/R/composer.R
+++ b/r/R/composer.R
@@ -47,7 +47,8 @@
 
   if (!is.null(curator_entry) && !is.null(codebook_entry)) {
     result$source <- "merged"
-    result$label <- curator_entry$description_es %||% codebook_entry$label %||% column_code
+    result$label <- curator_entry$description_es %||%
+      codebook_entry$label %||% column_code
     result$description_es <- curator_entry$description_es
     result$description_en <- curator_entry$description_en
     result$categories <- curator_entry$categories
@@ -68,8 +69,10 @@
     result$canonical_name <- canonical
 
   } else if (!is.null(codebook_entry)) {
-    has_categories <- !is.null(codebook_entry$categories) && length(codebook_entry$categories) > 0
-    has_question_text <- !is.null(codebook_entry$question_text) && nchar(codebook_entry$question_text) > 0
+    has_categories <- !is.null(codebook_entry$categories) &&
+      length(codebook_entry$categories) > 0
+    has_question_text <- !is.null(codebook_entry$question_text) &&
+      nchar(codebook_entry$question_text) > 0
 
     if (!has_categories && !has_question_text) {
       result$source <- "codebook (skeletal)"
@@ -103,7 +106,8 @@
   column_metadata <- list()
 
   for (col_name in names(df)) {
-    column_metadata[[col_name]] <- .compose_column_metadata(col_name, year, module)
+    column_metadata[[col_name]] <-
+      .compose_column_metadata(col_name, year, module)
   }
 
   column_metadata

--- a/r/inst/extdata/.gitkeep
+++ b/r/inst/extdata/.gitkeep
@@ -1,1 +1,0 @@
-# populated by scripts/sync_data_to_r.R at build time

--- a/scripts/sync_data_to_r.R
+++ b/scripts/sync_data_to_r.R
@@ -1,0 +1,74 @@
+#!/usr/bin/env Rscript
+# scripts/sync_data_to_r.R
+#
+# Sync canonical data files from data/ (monorepo root) to r/inst/extdata/
+# so the R package bundles them when installed.
+#
+# Used by .github/workflows/r-ci.yml before R CMD check.
+# Can also be run manually during development:
+#   Rscript scripts/sync_data_to_r.R
+#
+# CRAN compliance:
+# - 4 small JSONs (~135 KB total) bundled into the package
+# - dane_codebook.json (6.7 MB) explicitly EXCLUDED (lazy-downloaded at runtime)
+
+if (!requireNamespace("fs", quietly = TRUE)) {
+  stop("Package 'fs' is required. Install with: install.packages('fs')")
+}
+
+sync_files <- c(
+  "sources.json",
+  "variable_map.json",
+  "variable_module_map.json",
+  "epochs.json",
+  "codebook_release.json"
+)
+
+excluded <- c("dane_codebook.json")
+
+source_dir <- "data"
+target_dir <- "r/inst/extdata"
+
+if (!fs::dir_exists(source_dir)) {
+  stop(sprintf("Source directory missing: %s (run from monorepo root)",
+               source_dir))
+}
+
+fs::dir_create(target_dir, recurse = TRUE)
+
+synced <- character(0)
+missing <- character(0)
+
+for (f in sync_files) {
+  src <- fs::path(source_dir, f)
+  dst <- fs::path(target_dir, f)
+
+  if (!fs::file_exists(src)) {
+    missing <- c(missing, f)
+    next
+  }
+
+  fs::file_copy(src, dst, overwrite = TRUE)
+  synced <- c(synced, f)
+  cat(sprintf("Copied: %s -> %s\n", src, dst))
+}
+
+if (length(missing) > 0) {
+  warning(sprintf("Source files missing (skipped): %s",
+                  paste(missing, collapse = ", ")))
+}
+
+for (f in excluded) {
+  dst <- fs::path(target_dir, f)
+  if (fs::file_exists(dst)) {
+    stop(sprintf(
+      "Excluded file present in r/inst/extdata/: %s (must NOT be bundled to comply with CRAN size limit)",
+      f
+    ))
+  }
+}
+
+cat(sprintf("\nSync complete. %d files copied to %s.\n",
+            length(synced), target_dir))
+cat(sprintf("Excluded (lazy-downloaded at runtime): %s\n",
+            paste(excluded, collapse = ", ")))


### PR DESCRIPTION
## Summary
- Restores `scripts/sync_data_to_r.R` (was in closed PR #58) so the CI step `Sync canonical data into r/inst/extdata/` stops failing with "No such file".
- Replaces `r/LICENSE` with a CRAN-format DCF stub (`YEAR:` + `COPYRIGHT HOLDER:`), matching the `License: MIT + file LICENSE` declaration in `r/DESCRIPTION`.
- Moves `haven` and `vctrs` from `Imports` to `Suggests` since no R/ file uses them yet (Agent 5 will restore on labelled-survey work).
- Wraps 4 long lines in `r/R/composer.R` for lintr — semantics unchanged.
- Removes the obsolete `r/inst/extdata/.gitkeep` placeholder.

Together with `c617b4f` (docs + `@importFrom` annotations), this should leave R CMD check green with 0 ERROR / 0 WARNING / 0 NOTE on all 4 matrix jobs.

## Test plan
- [ ] CI: 4 R CMD check jobs pass (ubuntu/macos/windows R-release + ubuntu R-devel)
- [ ] CI: lintr passes with no line-length warnings
- [ ] Manual sanity: `Rscript scripts/sync_data_to_r.R` from repo root copies 5 JSONs and refuses to bundle `dane_codebook.json`

Generated with Claude Code