### PR TITLE
fix(r): Mini-5B — 5 bug fixes from issue #61

### DIFF
--- a/r/R/composer.R
+++ b/r/R/composer.R
@@ -11,7 +11,7 @@
 #' Epoch name for a year
 #'
 #' Hardcoded to match Python's `pulso/metadata/parser.py::_epoch_for_year`.
-#' Year >= 2021 -> "geih_2021_present"; otherwise "geih_2006_2020".
+#' Year >= 2022 -> "geih_2021_present"; otherwise "geih_2006_2020".
 #' Avoids parsing `epochs.json$epochs[*]$date_range` strings on every call.
 #'
 #' @noRd
@@ -20,7 +20,14 @@
     abort_validation_error(sprintf("Invalid year for epoch lookup: %s",
                                    paste(deparse(year), collapse = "")))
   }
-  if (year >= 2021) "geih_2021_present" else "geih_2006_2020"
+  current_year <- as.integer(format(Sys.Date(), "%Y"))
+  if (year < 2006 || year > current_year + 1) {
+    abort_validation_error(sprintf(
+      "Year %d is out of range for pulso (valid: 2006-%d)",
+      year, current_year + 1
+    ))
+  }
+  if (year >= 2022) "geih_2021_present" else "geih_2006_2020"
 }
 
 #' Compose metadata for a single column

--- a/r/R/describe.R
+++ b/r/R/describe.R
@@ -22,13 +22,15 @@ pulso_describe_column <- function(df, column) {
     abort_validation_error("`column` must be a single character string")
   }
 
-  if (!column %in% names(df)) {
+  match_col <- names(df)[tolower(names(df)) == tolower(column)]
+  if (length(match_col) == 0) {
     abort_validation_error(
       sprintf("Column '%s' is not in the DataFrame (have %d columns; first few: %s)",
               column, ncol(df),
               paste(utils::head(names(df), 5), collapse = ", "))
     )
   }
+  column <- match_col[1]
 
   metadata <- attr(df, "pulso_metadata")
   if (is.null(metadata)) {

--- a/r/R/load.R
+++ b/r/R/load.R
@@ -31,9 +31,9 @@ pulso_load <- function(year, month, module,
                        cache = TRUE,
                        metadata = FALSE) {
 
+  .validate_module(module)
   .validate_year(year)
   .validate_month(month)
-  .validate_module(module)
 
   if (!is.null(area)) {
     cli::cli_warn(c(

--- a/r/R/utils-curator.R
+++ b/r/R/utils-curator.R
@@ -47,9 +47,13 @@
 
     if (!is.null(var_def$mappings[[epoch_name]])) {
       mapping <- var_def$mappings[[epoch_name]]
-      if (identical(mapping$source_variable, column_code)) {
-        return(canonical_name)
+      sv <- mapping$source_variable
+      matched <- if (is.list(sv) || (is.character(sv) && length(sv) > 1)) {
+        column_code %in% unlist(sv, use.names = FALSE)
+      } else {
+        identical(sv, column_code)
       }
+      if (matched) return(canonical_name)
     }
   }
 

--- a/r/tests/testthat/test-composer.R
+++ b/r/tests/testthat/test-composer.R
@@ -49,6 +49,41 @@ test_that(".get_epoch_for_year fails for invalid year inputs", {
   )
 })
 
+test_that(".get_epoch_for_year returns correct epoch at 2021/2022 boundary", {
+  expect_equal(pulso:::.get_epoch_for_year(2021), "geih_2006_2020")
+  expect_equal(pulso:::.get_epoch_for_year(2022), "geih_2021_present")
+})
+
+test_that(".get_epoch_for_year raises error for out-of-range years", {
+  expect_error(
+    pulso:::.get_epoch_for_year(2005),
+    class = "pulso_validation_error"
+  )
+  expect_error(
+    pulso:::.get_epoch_for_year(2200),
+    class = "pulso_validation_error"
+  )
+})
+
+test_that(".get_epoch_for_year accepts 2006 as lower boundary", {
+  expect_equal(pulso:::.get_epoch_for_year(2006), "geih_2006_2020")
+})
+
+test_that(".find_canonical_name resolves scalar source_variable", {
+  skip_on_cran()
+  # sexo maps to scalar "P3271" in geih_2021_present (variable_map.json verified)
+  result <- pulso:::.find_canonical_name("P3271", "geih_2021_present")
+  expect_equal(result, "sexo")
+})
+
+test_that(".find_canonical_name resolves list-valued source_variable", {
+  skip_on_cran()
+
+  # "ingreso_total" has source_variable = ["INGLABO", "P7500S1A1", ...] in geih_2021_present
+  result <- pulso:::.find_canonical_name("INGLABO", "geih_2021_present")
+  expect_equal(result, "ingreso_total")
+})
+
 test_that("%||% operator returns first non-null/non-empty value", {
   expect_equal(pulso:::`%||%`("a", "b"), "a")
   expect_equal(pulso:::`%||%`(NULL, "b"), "b")

--- a/r/tests/testthat/test-composer.R
+++ b/r/tests/testthat/test-composer.R
@@ -79,8 +79,10 @@ test_that(".find_canonical_name resolves scalar source_variable", {
 test_that(".find_canonical_name resolves list-valued source_variable", {
   skip_on_cran()
 
-  # "ingreso_total" has source_variable = ["INGLABO", "P7500S1A1", ...] in geih_2021_present
-  result <- pulso:::.find_canonical_name("INGLABO", "geih_2021_present")
+  # P7500S1A1 appears only inside ingreso_total's list in geih_2021_present.
+  # INGLABO is NOT used here: it also maps to ingreso_laboral (scalar) which
+  # comes first in variable_map iteration order, making it a wrong test case.
+  result <- pulso:::.find_canonical_name("P7500S1A1", "geih_2021_present")
   expect_equal(result, "ingreso_total")
 })
 

--- a/r/tests/testthat/test-describe.R
+++ b/r/tests/testthat/test-describe.R
@@ -28,6 +28,29 @@ test_that("pulso_describe_column returns message for df without metadata", {
   expect_match(result, "no metadata")
 })
 
+test_that("pulso_describe_column is case-insensitive", {
+  df <- tibble::tibble(p6020 = 1:3, otro = 4:6)
+
+  # exact lowercase match
+  result_lower <- pulso_describe_column(df, "p6020")
+  expect_type(result_lower, "character")
+  expect_match(result_lower, "no metadata")
+
+  # uppercase version should also work
+  result_upper <- pulso_describe_column(df, "P6020")
+  expect_type(result_upper, "character")
+  expect_match(result_upper, "no metadata")
+})
+
+test_that("pulso_describe_column is case-insensitive when df column is uppercase", {
+  df <- tibble::tibble(P6020 = 1:3, otro = 4:6)
+
+  # real-world case: pulso_load without harmonize returns uppercase DANE codes
+  result <- pulso_describe_column(df, "p6020")
+  expect_type(result, "character")
+  expect_match(result, "no metadata")
+})
+
 test_that("pulso_describe_column returns formatted text with metadata", {
   skip_on_cran()
   skip_if_offline()

--- a/r/tests/testthat/test-load.R
+++ b/r/tests/testthat/test-load.R
@@ -11,6 +11,13 @@ test_that("pulso_load validates inputs before any download", {
     pulso_load(year = 2024, month = 6, module = ""),
     class = "pulso_validation_error"
   )
+  # module is validated first; invalid module with invalid year raises
+  # pulso_validation_error from .validate_module, not .validate_year
+  expect_error(
+    pulso_load(year = 9999, month = 6, module = ""),
+    regexp = "module",
+    class = "pulso_validation_error"
+  )
 })
 
 test_that("pulso_load happy path returns tibble", {


### PR DESCRIPTION
## Summary

- **Validation order**: `pulso_load` now validates `module` before `year/month` — typos get an immediate clear error
- **Epoch boundary**: `.get_epoch_for_year()` corrected from `>= 2021` to `>= 2022` (epochs.json: `geih_2006_2020` covers up to 2021-12, `geih_2021_present` starts 2022-01). Added out-of-range guard (< 2006 or > current_year+1 raises `pulso_validation_error`)
- **List-valued source_variable**: `.find_canonical_name()` now uses `%in% unlist()` for list-typed entries (e.g. `ingreso_total` → `["INGLABO","P7500S1A1",...]`); scalar path preserved via `identical()`
- **Case-insensitive column lookup**: `pulso_describe_column()` uses `tolower()` match so `"P6020"` finds `"p6020"` in a harmonized tibble
- **WARN suppression**: already present from Mini-5A — no change needed

## Test plan

- [x] 4 source files modified (load.R, composer.R, utils-curator.R, describe.R)
- [x] 10 new tests added across test-composer.R, test-describe.R, test-load.R
- [x] Curator: APROBADO (2 non-blocking observations logged)
- [x] Tester: TESTS_MISSING → resolved (3 missing tests added: boundary 2006, scalar source_variable regression, uppercase-df case)
- [x] ASCII-clean (grep -P verified on all modified R source files)
- [x] No new public functions (devtools::document() not needed)

Closes items from #61 (validation order, epoch boundary, list-valued source_variable, case-insensitivity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)