### PR TITLE
feat(r): Mini-5F -- vignette revival + tests + NEWS (Agente 5 completo)

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -1,11 +1,40 @@
-# pulso (development version)
+# pulso 0.1.0
 
-* Initial R skeleton. R port under construction.
+## Initial Release
 
-## Known limitations in v0.1.0
+pulso provides programmatic access to microdata from Colombia's Gran Encuesta
+Integrada de Hogares (GEIH), published monthly by DANE.
 
-* **Nested-zip layout (DANE 2024-03, 2024-04)**: these two periods ship the
-  per-format files inside a second zip wrapper (`CSV.zip`, `DTA.zip`,
-  `SAV.zip` as the outer archive contents). `pulso_load()` detects this and
-  raises `pulso_parse_error` with a v0.2.0 deferral notice. All other
-  periods from 2007 onward work normally.
+### Functions
+
+Loading data:
+
+* `pulso_load()` -- download and parse a single GEIH module
+* `pulso_load_merged()` -- download and merge multiple persona-level modules
+
+Column metadata:
+
+* `pulso_describe_column()` -- describe a single column in loaded data
+* `pulso_list_columns_metadata()` -- list metadata for all columns in a tibble
+
+Catalog and validation:
+
+* `pulso_list_validated_range()` -- list periods with verified downloads
+* `pulso_validation_status()` -- validation info for a specific period
+
+Module and variable discovery:
+
+* `pulso_describe()` -- describe a survey module
+* `pulso_describe_variable()` -- describe a canonical variable and its epoch mappings
+* `pulso_list_variables()` -- list canonical variables, optionally filtered by module
+
+### Known Limitations
+
+* Curator entries in variable_map.json are theoretical mappings pending empirical
+  verification against DANE microdata. Use `has_warning` column from
+  `pulso_list_variables()` to identify entries that need verification.
+* Nested-zip periods (2024-03, 2024-04) raise `pulso_parse_error` with a v0.2.0
+  deferral notice.
+* Shape A 2020-06 variant (single CSV with CLASE column) not yet supported.
+* Mixed-level merges (persona + hogar in same `pulso_load_merged()` call) deferred
+  to v0.2.0.

--- a/r/tests/testthat/test-describe-module.R
+++ b/r/tests/testthat/test-describe-module.R
@@ -20,3 +20,15 @@ test_that("pulso_describe errors on invalid module type", {
   expect_error(pulso_describe(123), class = "pulso_validation_error")
   expect_error(pulso_describe(""),  class = "pulso_validation_error")
 })
+
+test_that("pulso_describe output lists harmonized variable count", {
+  result <- pulso_describe("ocupados")
+  expect_match(result, "Harmonized variables", fixed = TRUE)
+  expect_match(result, "\\d+")  # count of canonical variables
+})
+
+test_that("pulso_describe includes epoch information", {
+  result <- pulso_describe("caracteristicas_generales")
+  expect_match(result, "Available in epochs", fixed = TRUE)
+  expect_match(result, "geih", ignore.case = TRUE)
+})

--- a/r/tests/testthat/test-load-merged.R
+++ b/r/tests/testthat/test-load-merged.R
@@ -52,3 +52,10 @@ test_that("pulso_load_merged metadata=TRUE attaches attr", {
                           metadata = TRUE)
   expect_false(is.null(attr(df, "pulso_metadata")))
 })
+
+test_that("pulso_load_merged errors on modules with NA values", {
+  expect_error(
+    pulso_load_merged(2024, 6, c("ocupados", NA, "caracteristicas_generales")),
+    class = "pulso_validation_error"
+  )
+})

--- a/r/tests/testthat/test-validation-status.R
+++ b/r/tests/testthat/test-validation-status.R
@@ -58,3 +58,19 @@ test_that("pulso_validation_status NA fields are NA for unvalidated period", {
   expect_true(is.na(result$checksum_sha256))
   expect_false(is.na(result$source_url))
 })
+
+test_that("pulso_validation_status works for earliest available period (2007-01)", {
+  # 2007-01 is the first period in sources.json
+  result <- pulso_validation_status(2007, 1)
+  expect_s3_class(result, "tbl_df")
+  expect_equal(result$year, 2007L)
+  expect_equal(result$month, 1L)
+})
+
+test_that("pulso_validation_status errors on future year (current year + 1)", {
+  future_year <- as.integer(format(Sys.Date(), "%Y")) + 1L
+  expect_error(
+    pulso_validation_status(future_year, 6),
+    class = "pulso_validation_error"
+  )
+})

--- a/r/vignettes/pulso.Rmd
+++ b/r/vignettes/pulso.Rmd
@@ -11,7 +11,7 @@ vignette: >
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  eval = FALSE
+  eval = TRUE
 )
 ```
 
@@ -20,7 +20,7 @@ knitr::opts_chunk$set(
 `pulso` provides programmatic access to Colombia's Gran Encuesta
 Integrada de Hogares (GEIH), the household labor force survey
 published monthly by DANE (Departamento Administrativo Nacional
-de Estadística).
+de Estadistica).
 
 ## Quick start
 
@@ -55,6 +55,32 @@ Or list metadata for all columns:
 ```{r, eval=FALSE}
 metadata_summary <- pulso_list_columns_metadata(df)
 print(metadata_summary)
+```
+
+## Exploring the variable catalog
+
+pulso ships a canonical variable catalog (`variable_map.json`) that
+maps harmonized variable names to their epoch-specific DANE source
+codes. These catalog functions work offline -- no data download needed.
+
+List all canonical variables (first 10 rows):
+
+```{r}
+library(pulso)
+vars <- pulso_list_variables()
+head(vars[, c("canonical_name", "module", "has_warning")], 10)
+```
+
+Describe a single canonical variable and its epoch mappings:
+
+```{r}
+cat(pulso_describe_variable("sexo"))
+```
+
+Describe a survey module (reads `sources.json` bundled in the package):
+
+```{r}
+cat(pulso_describe("ocupados"))
 ```
 
 ## What is GEIH?
@@ -103,18 +129,26 @@ Pass `cache = FALSE` to force re-download.
 
 ## Coverage and limitations
 
-This is `pulso` v0.1.0. Currently supported:
+`pulso` v0.1.0 supports the following:
 
 - Single year/month/module loads via `pulso_load()`
-- Metadata access via `pulso_describe_column()` and
+- Multi-module persona-level merges via `pulso_load_merged()`
+- Column metadata via `pulso_describe_column()` and
   `pulso_list_columns_metadata()`
-- Coverage: 2007 to present
+- Module discovery via `pulso_describe()`
+- Canonical variable catalog via `pulso_describe_variable()` and
+  `pulso_list_variables()`
+- Validation status queries via `pulso_validation_status()` and
+  `pulso_list_validated_range()`
+- Coverage: 2007-01 to present (sources.json)
 
-Planned for v0.2.0+:
+Known limitations:
 
-- `pulso_load_merged()` for multi-period loads
-- Area filtering (urbano/rural)
-- Full harmonization across epochs
-- Validation status checks
+- Curator entries in `variable_map.json` are theoretical mappings
+  pending empirical verification. Use `has_warning` from
+  `pulso_list_variables()` to identify these entries.
+- Nested-zip periods (2024-03, 2024-04) are deferred to v0.2.0.
+- Mixed-level merges (persona + hogar) in `pulso_load_merged()` are
+  deferred to v0.2.0.
 
 See the GitHub issues for roadmap and known limitations.


### PR DESCRIPTION
## Summary

Final mini of Agente 5. Quality pass: no new functions.

- **Vignette revival**: changed global `eval=FALSE` to `eval=TRUE` in setup chunk; added 3 offline executable chunks (`pulso_list_variables()`, `pulso_describe_variable("sexo")`, `pulso_describe("ocupados")`) that run without DANE downloads; all existing `pulso_load` / `pulso_describe_column` chunks retain explicit `eval=FALSE` for CRAN compliance. Fixed one non-ASCII byte (`Estadistica` without accent).
- **5 new tests** across 3 files: NA in `modules` vector triggers `pulso_validation_error`; `pulso_describe` output contains digit count and "geih" epoch string; `pulso_validation_status(2007, 1)` returns correct tibble; dynamic `future_year + 1` triggers `pulso_validation_error`.
- **NEWS.md**: full v0.1.0 changelog with all 9 functions and 4 known limitations.

## Agent pipeline

Coder → Curator (REVISAR → 1 comment patch) → Tester (TESTS_OK — ran R 4.5.2 locally: 32 PASS for validation-status, 12 PASS for describe-module, vignette chunks all compile)

## Test plan

- [ ] 184 existing + 5 new = 189 PASS offline (2 skip_on_ci remain skipped)
- [ ] Vignette builds with `--no-build-vignettes` on CI (no chunk execution in CI)
- [ ] No new p6020/p3271 hardcoded in new tests
- [ ] NEWS.md ASCII-clean
- [ ] CI green on all 4 platforms + lintr

🤖 Generated with [Claude Code](https://claude.com/claude-code)